### PR TITLE
support MaxScan in queries

### DIFF
--- a/session.go
+++ b/session.go
@@ -2264,6 +2264,21 @@ func (q *Query) Hint(indexKey ...string) *Query {
 	return q
 }
 
+// SetMaxScan constrains the query to only scan the specified number of
+// documents when fulfilling the query.
+//
+// Relevant documentation:
+//
+//		 http://docs.mongodb.org/manual/reference/operator/meta/maxScan
+//
+func (q *Query) SetMaxScan(n int) *Query {
+	q.m.Lock()
+	q.op.options.MaxScan = n
+	q.op.hasOptions = true
+	q.m.Unlock()
+	return q
+}
+
 // Snapshot will force the performed query to make use of an available
 // index on the _id field to prevent the same document from being returned
 // more than once in a single iteration. This might happen without this

--- a/session_test.go
+++ b/session_test.go
@@ -1042,6 +1042,25 @@ func (s *S) TestQueryExplain(c *C) {
 	c.Assert(n, Equals, 2)
 }
 
+func (s *S) TestMaxScanned(c *C) {
+	session, err := mgo.Dial("localhost:40001")
+	c.Assert(err, IsNil)
+	defer session.Close()
+	coll := session.DB("mydb").C("mycoll")
+
+	ns := []int{40, 41, 42}
+	for _, n := range ns {
+		err := coll.Insert(M{"n": n})
+		c.Assert(err, IsNil)
+	}
+
+	query := coll.Find(nil).SetMaxScan(2)
+	var result []M
+	err = query.All(&result)
+	c.Assert(err, IsNil)
+	c.Assert(result, HasLen, 2)
+}
+
 func (s *S) TestQueryHint(c *C) {
 	session, err := mgo.Dial("localhost:40001")
 	c.Assert(err, IsNil)

--- a/socket.go
+++ b/socket.go
@@ -86,6 +86,7 @@ type queryWrapper struct {
 	Explain        bool        "$explain,omitempty"
 	Snapshot       bool        "$snapshot,omitempty"
 	ReadPreference bson.D      "$readPreference,omitempty"
+	MaxScan        int         "$maxScan,omitempty"
 }
 
 func (op *queryOp) finalQuery(socket *mongoSocket) interface{} {


### PR DESCRIPTION
We don't have a way to set `$maxScan` in queries in the MGO driver right now. We at Parse.com use this feature. This is diff to implement it. 

If you tell me how to run the tests I can run and add a test case. 
