### PR TITLE
mgo: optimize seeking to end of GridFS file

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -10,8 +10,8 @@ package mgo
 //   http://blog.mongodb.org/post/84922794768/mongodbs-new-bulk-api
 //
 type Bulk struct {
-	c *Collection 
-	ordered bool 
+	c       *Collection
+	ordered bool
 	inserts []interface{}
 }
 
@@ -44,7 +44,7 @@ func (c *Collection) Bulk() *Bulk {
 }
 
 // Unordered puts the bulk operation in unordered mode.
-// 
+//
 // In unordered mode the indvidual operations may be sent
 // out of order, which means latter operations may proceed
 // even if prior ones have failed.

--- a/cluster.go
+++ b/cluster.go
@@ -396,7 +396,7 @@ func (cluster *mongoCluster) server(addr string, tcpaddr *net.TCPAddr) *mongoSer
 
 func resolveAddr(addr string) (*net.TCPAddr, error) {
 	// This hack allows having a timeout on resolution.
-	conn, err := net.DialTimeout("udp", addr, 10 * time.Second)
+	conn, err := net.DialTimeout("udp", addr, 10*time.Second)
 	if err != nil {
 		log("SYNC Failed to resolve server address: ", addr)
 		return nil, errors.New("failed to resolve server address: " + addr)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1184,7 +1184,7 @@ func (s *S) TestPoolLimitSimple(c *C) {
 		// Put the one socket back in the pool, freeing it for the copy.
 		session.Refresh()
 		delay := <-done
-		c.Assert(delay > 300 * time.Millisecond, Equals, true, Commentf("Delay: %s", delay))
+		c.Assert(delay > 300*time.Millisecond, Equals, true, Commentf("Delay: %s", delay))
 	}
 }
 

--- a/gridfs.go
+++ b/gridfs.go
@@ -651,6 +651,14 @@ func (file *GridFile) Seek(offset int64, whence int) (pos int64, err error) {
 	if offset > file.doc.Length {
 		return file.offset, errors.New("seek past end of file")
 	}
+	if offset == file.doc.Length {
+		// If we're seeking to the end of the file,
+		// no need to read anything. This enables
+		// a client to find the size of the file using only the
+		// io.ReadSeeker interface with low overhead.
+		file.offset = offset
+		return file.offset, nil
+	}
 	chunk := int(offset / int64(file.doc.ChunkSize))
 	if chunk+1 == file.chunk && offset >= file.offset {
 		file.rbuf = file.rbuf[int(offset-file.offset):]

--- a/gridfs_test.go
+++ b/gridfs_test.go
@@ -31,9 +31,9 @@ import (
 	"os"
 	"time"
 
+	. "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
-	. "gopkg.in/check.v1"
 )
 
 func (s *S) TestGridFSCreate(c *C) {
@@ -484,6 +484,13 @@ func (s *S) TestGridFSSeek(c *C) {
 	_, err = file.Read(b)
 	c.Assert(err, IsNil)
 	c.Assert(b, DeepEquals, []byte("nopqr"))
+
+	o, err = file.Seek(0, os.SEEK_END)
+	c.Assert(err, IsNil)
+	c.Assert(o, Equals, int64(22))
+	n, err = file.Read(b)
+	c.Assert(err, Equals, io.EOF)
+	c.Assert(n, Equals, 0)
 
 	o, err = file.Seek(-10, os.SEEK_END)
 	c.Assert(err, IsNil)

--- a/log.go
+++ b/log.go
@@ -42,9 +42,9 @@ type log_Logger interface {
 }
 
 var (
-	globalLogger   log_Logger
-	globalDebug    bool
-	globalMutex sync.Mutex
+	globalLogger log_Logger
+	globalDebug  bool
+	globalMutex  sync.Mutex
 )
 
 // RACE WARNING: There are known data races when logging, which are manually

--- a/raceoff.go
+++ b/raceoff.go
@@ -3,4 +3,3 @@
 package mgo
 
 const raceDetector = false
-

--- a/server.go
+++ b/server.go
@@ -295,7 +295,7 @@ func (server *mongoServer) pinger(loop bool) {
 			time.Sleep(delay)
 		}
 		op := op
-		socket, _, err := server.AcquireSocket(0, 3 * delay)
+		socket, _, err := server.AcquireSocket(0, 3*delay)
 		if err == nil {
 			start := time.Now()
 			_, _ = socket.SimpleQuery(&op)


### PR DESCRIPTION
This makes it more efficient to use http.ServeContent with GridFS-backed
content.

Also gofmt'd the source.
