### PR TITLE
MGO-35 add support for ServiceHostname for GSSAPI, test for ServiceName

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -246,7 +246,13 @@ func (socket *mongoSocket) loginPlain(cred Credential) error {
 }
 
 func (socket *mongoSocket) loginSASL(cred Credential) error {
-	sasl, err := saslNew(cred, socket.Server().Addr)
+	var sasl saslStepper;
+	var err error;
+	if len(cred.ServiceHostname) > 0 {
+		sasl, err = saslNew(cred, cred.ServiceHostname)
+	} else {
+		sasl, err = saslNew(cred, socket.Server().Addr)
+	}
 	if err != nil {
 		return err
 	}

--- a/auth.go
+++ b/auth.go
@@ -249,7 +249,7 @@ func (socket *mongoSocket) loginSASL(cred Credential) error {
 	var sasl saslStepper
 	var err error
 	if len(cred.ServiceHost) > 0 {
-		sasl, err = saslNew(cred, cred.ServiceHostname)
+		sasl, err = saslNew(cred, cred.ServiceHost)
 	} else {
 		sasl, err = saslNew(cred, socket.Server().Addr)
 	}

--- a/auth.go
+++ b/auth.go
@@ -246,9 +246,9 @@ func (socket *mongoSocket) loginPlain(cred Credential) error {
 }
 
 func (socket *mongoSocket) loginSASL(cred Credential) error {
-	var sasl saslStepper;
-	var err error;
-	if len(cred.ServiceHostname) > 0 {
+	var sasl saslStepper
+	var err error
+	if len(cred.ServiceHost) > 0 {
 		sasl, err = saslNew(cred, cred.ServiceHostname)
 	} else {
 		sasl, err = saslNew(cred, socket.Server().Addr)

--- a/auth_test.go
+++ b/auth_test.go
@@ -939,70 +939,68 @@ func (s *S) TestAuthKerberosURL(c *C) {
 
 func (s *S) TestAuthKerberosServiceName(c *C) {
 	if !*kerberosFlag {
-                c.Skip("no -kerberos")
-        }
+		c.Skip("no -kerberos")
+	}
 
 	wrongServiceName := "wrong"
 	rightServiceName := "mongodb"
 
-        cred := &mgo.Credential{
-                Username:  kerberosUser,
-                Mechanism: "GSSAPI",
-                Service: wrongServiceName,
-        }
+	cred := &mgo.Credential{
+		Username:  kerberosUser,
+		Mechanism: "GSSAPI",
+		Service: wrongServiceName,
+	}
 
 	c.Logf("Connecting to %s...", kerberosHost)
-        session, err := mgo.Dial(kerberosHost)
-        c.Assert(err, IsNil)
-        defer session.Close()
+	session, err := mgo.Dial(kerberosHost)
+	c.Assert(err, IsNil)
+	defer session.Close()
 
 	c.Logf("Authenticating with incorrect service name...")
-        err = session.Login(cred)
-        c.Assert(err, ErrorMatches,
-		".*Server wrong/mmscustmongo.10gen.me@10GEN.ME not found.*")
+	err = session.Login(cred)
+	c.Assert(err, ErrorMatches, ".*Server wrong/mmscustmongo.10gen.me@10GEN.ME not found.*")
 
 	cred.Service = rightServiceName
 	c.Logf("Authenticating with correct service name...")
-        err = session.Login(cred)
-        c.Assert(err, IsNil)
-        c.Logf("Authenticated!")
+	err = session.Login(cred)
+	c.Assert(err, IsNil)
+	c.Logf("Authenticated!")
 
-        names, err := session.DatabaseNames()
-        c.Assert(err, IsNil)
-        c.Assert(len(names) > 0, Equals, true)
+	names, err := session.DatabaseNames()
+	c.Assert(err, IsNil)
+	c.Assert(len(names) > 0, Equals, true)
 }
 
-func (s *S) TestAuthKerberosServiceHostname(c *C) {
+func (s *S) TestAuthKerberosServiceHost(c *C) {
 	if !*kerberosFlag {
-                c.Skip("no -kerberos")
-        }
+		c.Skip("no -kerberos")
+	}
 
-	wrongServiceHostname := "eggs.bacon.tk"
-	rightServiceHostname := "mmscustmongo.10gen.me"
+	wrongServiceHost := "eggs.bacon.tk"
+	rightServiceHost := "mmscustmongo.10gen.me"
 
-        cred := &mgo.Credential{
-                Username:        kerberosUser,
-                Mechanism:       "GSSAPI",
-		ServiceHostname: wrongServiceHostname,
-        }
+	cred := &mgo.Credential{
+		Username:    kerberosUser,
+		Mechanism:   "GSSAPI",
+		ServiceHost: wrongServiceHostname,
+	}
 
-        c.Logf("Connecting to %s...", kerberosHost)
-        session, err := mgo.Dial(kerberosHost)
-        c.Assert(err, IsNil)
-        defer session.Close()
+	c.Logf("Connecting to %s...", kerberosHost)
+	session, err := mgo.Dial(kerberosHost)
+	c.Assert(err, IsNil)
+	defer session.Close()
 
-        c.Logf("Authenticating with incorrect service hostname...")
-        err = session.Login(cred)
-        c.Assert(err, ErrorMatches,
-                ".*Server krbtgt/BACON.TK@10GEN.ME not found.*")
+	c.Logf("Authenticating with incorrect service host...")
+	err = session.Login(cred)
+	c.Assert(err, ErrorMatches, ".*Server krbtgt/BACON.TK@10GEN.ME not found.*")
 
-        cred.ServiceHostname = rightServiceHostname
-        c.Logf("Authenticating with correct service hostname...")
-        err = session.Login(cred)
-        c.Assert(err, IsNil)
-        c.Logf("Authenticated!")
+	cred.ServiceHost = rightServiceHostname
+	c.Logf("Authenticating with correct service host...")
+	err = session.Login(cred)
+	c.Assert(err, IsNil)
+	c.Logf("Authenticated!")
 
-        names, err := session.DatabaseNames()
-        c.Assert(err, IsNil)
-        c.Assert(len(names) > 0, Equals, true)
+	names, err := session.DatabaseNames()
+	c.Assert(err, IsNil)
+	c.Assert(len(names) > 0, Equals, true)
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -982,7 +982,7 @@ func (s *S) TestAuthKerberosServiceHost(c *C) {
 	cred := &mgo.Credential{
 		Username:    kerberosUser,
 		Mechanism:   "GSSAPI",
-		ServiceHost: wrongServiceHostname,
+		ServiceHost: wrongServiceHost,
 	}
 
 	c.Logf("Connecting to %s...", kerberosHost)
@@ -994,7 +994,7 @@ func (s *S) TestAuthKerberosServiceHost(c *C) {
 	err = session.Login(cred)
 	c.Assert(err, ErrorMatches, ".*Server krbtgt/BACON.TK@10GEN.ME not found.*")
 
-	cred.ServiceHost = rightServiceHostname
+	cred.ServiceHost = rightServiceHost
 	c.Logf("Authenticating with correct service host...")
 	err = session.Login(cred)
 	c.Assert(err, IsNil)

--- a/session.go
+++ b/session.go
@@ -304,7 +304,7 @@ type DialInfo struct {
 	Service string
 
 	// ServiceHost defines which hostname to use when authenticating
-        // with the GSSAPI mechanism. If not specified, defaults to the MongoDB
+	// with the GSSAPI mechanism. If not specified, defaults to the MongoDB
 	// server's address.
 	ServiceHost string
 
@@ -603,8 +603,8 @@ type Credential struct {
 	Service string
 
 	// ServiceHost defines which hostname to use when authenticating
-        // with the GSSAPI mechanism. If not specified, defaults to the MongoDB
-        // server's address.
+	// with the GSSAPI mechanism. If not specified, defaults to the MongoDB
+	// server's address.
 	ServiceHost string
 
 	// Mechanism defines the protocol for credential negotiation.

--- a/session.go
+++ b/session.go
@@ -303,10 +303,10 @@ type DialInfo struct {
 	// mechanism. Defaults to "mongodb".
 	Service string
 
-	// ServiceHostname defines which hostname to use when authenticating
+	// ServiceHost defines which hostname to use when authenticating
         // with the GSSAPI mechanism. If not specified, defaults to the MongoDB
 	// server's address.
-	ServiceHostname string
+	ServiceHost string
 
 	// Mechanism defines the protocol for credential negotiation.
 	// Defaults to "MONGODB-CR".
@@ -376,12 +376,12 @@ func DialWithInfo(info *DialInfo) (*Session, error) {
 			source = "$external"
 		}
 		session.dialCred = &Credential{
-			Username:        info.Username,
-			Password:        info.Password,
-			Mechanism:       info.Mechanism,
-			Service:         info.Service,
-			ServiceHostname: info.ServiceHostname,
-			Source:          source,
+			Username:    info.Username,
+			Password:    info.Password,
+			Mechanism:   info.Mechanism,
+			Service:     info.Service,
+			ServiceHost: info.ServiceHost,
+			Source:      source,
 		}
 		session.creds = []Credential{*session.dialCred}
 	}
@@ -602,10 +602,10 @@ type Credential struct {
 	// mechanism. Defaults to "mongodb".
 	Service string
 
-	// ServiceHostname defines which hostname to use when authenticating
+	// ServiceHost defines which hostname to use when authenticating
         // with the GSSAPI mechanism. If not specified, defaults to the MongoDB
         // server's address.
-	ServiceHostname string
+	ServiceHost string
 
 	// Mechanism defines the protocol for credential negotiation.
 	// Defaults to "MONGODB-CR".

--- a/session.go
+++ b/session.go
@@ -303,6 +303,11 @@ type DialInfo struct {
 	// mechanism. Defaults to "mongodb".
 	Service string
 
+	// ServiceHostname defines which hostname to use when authenticating
+        // with the GSSAPI mechanism. If not specified, defaults to the MongoDB
+	// server's address.
+	ServiceHostname string
+
 	// Mechanism defines the protocol for credential negotiation.
 	// Defaults to "MONGODB-CR".
 	Mechanism string
@@ -371,11 +376,12 @@ func DialWithInfo(info *DialInfo) (*Session, error) {
 			source = "$external"
 		}
 		session.dialCred = &Credential{
-			Username:  info.Username,
-			Password:  info.Password,
-			Mechanism: info.Mechanism,
-			Service:   info.Service,
-			Source:    source,
+			Username:        info.Username,
+			Password:        info.Password,
+			Mechanism:       info.Mechanism,
+			Service:         info.Service,
+			ServiceHostname: info.ServiceHostname,
+			Source:          source,
 		}
 		session.creds = []Credential{*session.dialCred}
 	}
@@ -595,6 +601,11 @@ type Credential struct {
 	// Service defines the service name to use when authenticating with the GSSAPI
 	// mechanism. Defaults to "mongodb".
 	Service string
+
+	// ServiceHostname defines which hostname to use when authenticating
+        // with the GSSAPI mechanism. If not specified, defaults to the MongoDB
+        // server's address.
+	ServiceHostname string
 
 	// Mechanism defines the protocol for credential negotiation.
 	// Defaults to "MONGODB-CR".


### PR DESCRIPTION
See corresponding code in server's MongoClient [here](https://github.com/mongodb/mongo/blob/be05259d36ec5f44c821c8f2d103a4ee83ebaf53/src/mongo/client/sasl_client_session.cpp#L279-285)
