### PR TITLE
simple benchmarks for raw optimization 

### DIFF
--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -1448,14 +1448,14 @@ type BenchRawT struct {
 	D []float64
 }
 
-func BenchmarkUnmarhsalStruct(b *testing.B) {
+func (s *S) BenchmarkUnmarhsalStruct(c *C) {
 	v := BenchT{A: "A", D: "D", E: "E"}
 	data, err := bson.Marshal(&v)
 	if err != nil {
 		panic(err)
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	c.ResetTimer()
+	for i := 0; i < c.N; i++ {
 		err = bson.Unmarshal(data, &v)
 	}
 	if err != nil {
@@ -1463,14 +1463,14 @@ func BenchmarkUnmarhsalStruct(b *testing.B) {
 	}
 }
 
-func BenchmarkUnmarhsalMap(b *testing.B) {
+func (s *S) BenchmarkUnmarhsalMap(c *C) {
 	m := bson.M{"a": "a", "d": "d", "e": "e"}
 	data, err := bson.Marshal(&m)
 	if err != nil {
 		panic(err)
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	c.ResetTimer()
+	for i := 0; i < c.N; i++ {
 		err = bson.Unmarshal(data, &m)
 	}
 	if err != nil {
@@ -1478,7 +1478,7 @@ func BenchmarkUnmarhsalMap(b *testing.B) {
 	}
 }
 
-func BenchmarkUnmarshalRaw(b *testing.B) {
+func (s *S) BenchmarkUnmarshalRaw(c *C) {
 	var err error
 	m := BenchRawT{
 		A: "test_string",
@@ -1494,8 +1494,8 @@ func BenchmarkUnmarshalRaw(b *testing.B) {
 		panic(err)
 	}
 	raw := bson.Raw{}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	c.ResetTimer()
+	for i := 0; i < c.N; i++ {
 		err = bson.Unmarshal(data, &raw)
 	}
 	if err != nil {

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -1441,6 +1441,13 @@ type BenchT struct {
 	A, B, C, D, E, F string
 }
 
+type BenchRawT struct {
+	A string
+	B int
+	C bson.M
+	D []float64
+}
+
 func BenchmarkUnmarhsalStruct(b *testing.B) {
 	v := BenchT{A: "A", D: "D", E: "E"}
 	data, err := bson.Marshal(&v)
@@ -1465,6 +1472,31 @@ func BenchmarkUnmarhsalMap(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		err = bson.Unmarshal(data, &m)
+	}
+	if err != nil {
+		panic(err)
+	}
+}
+
+func BenchmarkUnmarshalRaw(b *testing.B) {
+	var err error
+	m := BenchRawT{
+		A: "test_string",
+		B: 123,
+		C: bson.M{
+			"subdoc_int": 12312,
+			"subdoc_doc": bson.M{"1": 1},
+		},
+		D: []float64{0.0, 1.3333, -99.9997, 3.1415},
+	}
+	data, err := bson.Marshal(&m)
+	if err != nil {
+		panic(err)
+	}
+	raw := bson.Raw{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err = bson.Unmarshal(data, &raw)
 	}
 	if err != nil {
 		panic(err)

--- a/session_test.go
+++ b/session_test.go
@@ -35,6 +35,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	. "gopkg.in/check.v1"
@@ -3253,4 +3254,46 @@ func (s *S) TestSetCursorTimeout(c *C) {
 	c.Assert(iter.Next(&result), Equals, true)
 	c.Assert(result.N, Equals, 42)
 	c.Assert(iter.Next(&result), Equals, false)
+}
+
+// --------------------------------------------------------------------------
+// Some benchmarks that require a running database.
+
+func BenchmarkFindIterRaw(b *testing.B) {
+	err := run("mongo --nodb testdb/dropall.js")
+	if err != nil {
+		panic(err)
+	}
+	session, err := mgo.Dial("localhost:40001")
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+	coll := session.DB("mydb").C("mycoll")
+
+	// Insert 10,000 test documents
+	for i := 0; i < 10000; i++ {
+		doc := bson.M{
+			"_id": i,
+			"f2":  "a short string",
+			"f3":  bson.M{"1": "one", "2": float64(2)},
+			"f4":  []string{"a", "b", "c", "d", "e", "f", "g"},
+		}
+		err := coll.Insert(doc)
+		if err != nil {
+			panic(err)
+		}
+	}
+	raw := bson.Raw{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		iter := coll.Find(nil).Iter()
+		for iter.Next(&raw) {
+		}
+		if err := iter.Err(); err != nil {
+			panic(err)
+		}
+	}
+
 }

--- a/session_test.go
+++ b/session_test.go
@@ -35,7 +35,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"testing"
 	"time"
 
 	. "gopkg.in/check.v1"
@@ -3259,7 +3258,7 @@ func (s *S) TestSetCursorTimeout(c *C) {
 // --------------------------------------------------------------------------
 // Some benchmarks that require a running database.
 
-func BenchmarkFindIterRaw(b *testing.B) {
+func (s *S) BenchmarkFindIterRaw(c *C) {
 	err := run("mongo --nodb testdb/dropall.js")
 	if err != nil {
 		panic(err)
@@ -3286,8 +3285,8 @@ func BenchmarkFindIterRaw(b *testing.B) {
 	}
 	raw := bson.Raw{}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	c.ResetTimer()
+	for i := 0; i < c.N; i++ {
 		iter := coll.Find(nil).Iter()
 		for iter.Next(&raw) {
 		}


### PR DESCRIPTION
Added two benchmarks for reading into bson.Raw. The one we really need optimized is the "BenchmarkFindIterRaw" case, but I also included "BenchmarkUnmarshalRaw" because it might be nice to have something of a smaller scope too. Let me know if you have any questions.

-Kyle
