### PR TITLE
Support for DBPointer in bson package

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -386,6 +386,14 @@ type JavaScript struct {
 	Scope interface{}
 }
 
+// DBPointer is a type that refers to a document in some namespace by wrapping
+// a string containing the namespace itself, and the ObjectId in which the _id
+// of the document is contained
+type DBPointer struct {
+	Namespace string
+	Id        ObjectId
+}
+
 const initialBufferSize = 64
 
 func handleErr(err *error) {

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -139,6 +139,8 @@ var allItems = []testItemType{
 		"\x06_\x00"},
 	{bson.M{"_": bson.ObjectId("0123456789ab")},
 		"\x07_\x000123456789ab"},
+	{bson.M{"_": bson.DBPointer{"testnamespace", bson.ObjectId("0123456789ab")}},
+		"\x0C_\x00\x0e\x00\x00\x00testnamespace\x000123456789ab"},
 	{bson.M{"_": false},
 		"\x08_\x00\x00"},
 	{bson.M{"_": true},

--- a/bson/decode.go
+++ b/bson/decode.go
@@ -499,6 +499,8 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 		in = nil
 	case 0x0B: // RegEx
 		in = d.readRegEx()
+	case 0x0C:
+		in = DBPointer{Namespace: d.readStr(), Id: ObjectId(d.readBytes(12))}
 	case 0x0D: // JavaScript without scope
 		in = JavaScript{Code: d.readStr()}
 	case 0x0E: // Symbol

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -43,6 +43,7 @@ import (
 var (
 	typeBinary         = reflect.TypeOf(Binary{})
 	typeObjectId       = reflect.TypeOf(ObjectId(""))
+	typeDBPointer      = reflect.TypeOf(DBPointer{"", ObjectId("")})
 	typeSymbol         = reflect.TypeOf(Symbol(""))
 	typeMongoTimestamp = reflect.TypeOf(MongoTimestamp(0))
 	typeOrderKey       = reflect.TypeOf(MinKey)
@@ -380,6 +381,15 @@ func (e *encoder) addElem(name string, v reflect.Value, minSize bool) {
 		case Binary:
 			e.addElemName('\x05', name)
 			e.addBinary(s.Kind, s.Data)
+
+		case DBPointer:
+			e.addElemName('\x0C', name)
+			e.addStr(s.Namespace)
+			if len(s.Id) != 12 {
+				panic("ObjectIDs must be exactly 12 bytes long (got " +
+					strconv.Itoa(len(s.Id)) + ")")
+			}
+			e.addBytes([]byte(s.Id)...)
 
 		case RegEx:
 			e.addElemName('\x0B', name)


### PR DESCRIPTION
According to bsonspec.org, this is a deprecated type, however there are some mongodump/mongorestore tests that rely on encoding and decoding of objects which contain it. This commit adds support for the DBPointer type and includes a test for it.
