### PR TITLE
Quick fix for Kerberos: don't use hardcoded userPlusRealm length

### DIFF
--- a/sasl/sasl_windows.c
+++ b/sasl/sasl_windows.c
@@ -102,6 +102,7 @@ int sspi_send_client_authz_id(CtxtHandle *context, PVOID *buffer, ULONG *buffer_
 
 	status = call_sspi_encrypt_message(context, SECQOP_WRAP_NO_ENCRYPT, &wrapBufDesc, 0);
 	if (status != SEC_E_OK) {
+		free(msg);
 		return status;
 	}
 
@@ -112,5 +113,6 @@ int sspi_send_client_authz_id(CtxtHandle *context, PVOID *buffer, ULONG *buffer_
 	memcpy(*buffer + wrapBufs[0].cbBuffer, wrapBufs[1].pvBuffer, wrapBufs[1].cbBuffer);
 	memcpy(*buffer + wrapBufs[0].cbBuffer + wrapBufs[1].cbBuffer, wrapBufs[2].pvBuffer, wrapBufs[2].cbBuffer);
 
+	free(msg);
 	return SEC_E_OK;
 }

--- a/sasl/sasl_windows.c
+++ b/sasl/sasl_windows.c
@@ -73,13 +73,14 @@ int sspi_send_client_authz_id(CtxtHandle *context, PVOID *buffer, ULONG *buffer_
 		return status;
 	}
 
-	int msgSize = 4 + 25;
+	size_t user_plus_realm_length = strlen(user_plus_realm);
+	int msgSize = 4 + user_plus_realm_length;
 	char *msg = malloc((sizes.cbSecurityTrailer + msgSize + sizes.cbBlockSize) * sizeof(char));
 	msg[sizes.cbSecurityTrailer + 0] = 1;
 	msg[sizes.cbSecurityTrailer + 1] = 0;
 	msg[sizes.cbSecurityTrailer + 2] = 0;
 	msg[sizes.cbSecurityTrailer + 3] = 0;
-	memcpy(&msg[sizes.cbSecurityTrailer + 4], user_plus_realm, 25);
+	memcpy(&msg[sizes.cbSecurityTrailer + 4], user_plus_realm, user_plus_realm_length);
 
 	SecBuffer wrapBufs[3];
 	SecBufferDesc wrapBufDesc;

--- a/sasl/sasl_windows.go
+++ b/sasl/sasl_windows.go
@@ -36,7 +36,6 @@ type saslSession struct {
 
 	// Keep track of pointers we need to explicitly free
 	stringsToFree []*C.char
-	buffersToFree []C.PVOID
 }
 
 var initError error

--- a/sasl/sasl_windows.go
+++ b/sasl/sasl_windows.go
@@ -93,9 +93,6 @@ func (ss *saslSession) Close() {
 	for _, cstr := range ss.stringsToFree {
 		C.free(unsafe.Pointer(cstr))
 	}
-	for _, cbuf := range ss.buffersToFree {
-		C.free(unsafe.Pointer(cbuf))
-	}
 }
 
 func (ss *saslSession) Step(serverData []byte) (clientData []byte, done bool, err error) {
@@ -113,11 +110,12 @@ func (ss *saslSession) Step(serverData []byte) (clientData []byte, done bool, er
 	if ss.authComplete {
 		// Step 3: last bit of magic to use the correct server credentials
 		status = C.sspi_send_client_authz_id(&ss.context, &buffer, &bufferLength, ss.cstr(ss.userPlusRealm))
-		ss.buffersToFree = append(ss.buffersToFree, buffer)
 	} else {
 		// Step 1 + Step 2: set up security context with the server and TGT
 		status = C.sspi_step(&ss.credHandle, ss.hasContext, &ss.context, &buffer, &bufferLength, ss.cstr(ss.target))
-		ss.buffersToFree = append(ss.buffersToFree, buffer)
+	}
+	if buffer != C.PVOID(nil) {
+		defer C.free(unsafe.Pointer(buffer))
 	}
 	if status != C.SEC_E_OK && status != C.SEC_I_CONTINUE_NEEDED {
 		ss.errored = true


### PR DESCRIPTION
Hey Gustavo,

Looks like I made a silly mistake in my SSPI code, forgot to take out the hardcoded username length.
