### PR TITLE
Improved document key sorting and support for struct document ids

### DIFF
--- a/txn/debug.go
+++ b/txn/debug.go
@@ -70,12 +70,12 @@ func argsForLog(args []interface{}) []interface{} {
 			args[i] = lst
 		case map[docKey][]bson.ObjectId:
 			buf := &bytes.Buffer{}
-			var dkeys docKeys
+			var dkeys sortableDocKeys
 			for dkey := range v {
-				dkeys = append(dkeys, dkey)
+				dkeys = append(dkeys, newSortableDocKey(dkey))
 			}
 			sort.Sort(dkeys)
-			for i, dkey := range dkeys {
+			for i, dkey := range dkeys.GetKeys() {
 				if i > 0 {
 					buf.WriteByte(' ')
 				}
@@ -91,12 +91,12 @@ func argsForLog(args []interface{}) []interface{} {
 			args[i] = buf.String()
 		case map[docKey][]int64:
 			buf := &bytes.Buffer{}
-			var dkeys docKeys
+			var dkeys sortableDocKeys
 			for dkey := range v {
-				dkeys = append(dkeys, dkey)
+				dkeys = append(dkeys, newSortableDocKey(dkey))
 			}
 			sort.Sort(dkeys)
-			for i, dkey := range dkeys {
+			for i, dkey := range dkeys.GetKeys() {
 				if i > 0 {
 					buf.WriteByte(' ')
 				}

--- a/txn/flusher.go
+++ b/txn/flusher.go
@@ -2,7 +2,6 @@ package txn
 
 import (
 	"fmt"
-	"sort"
 
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -225,10 +224,10 @@ func (f *flusher) prepare(t *transaction, force bool) (revnos []int64, err error
 	}
 	f.debugf("Preparing %s", t)
 
-	// Iterate in a stable way across all runners. This isn't
-	// strictly required, but reduces the chances of cycles.
+	// docKeys is sorted to support stable iteration across all
+	// runners. This isn't strictly required, but reduces the chances
+	// of cycles.
 	dkeys := t.docKeys()
-	sort.Sort(dkeys)
 
 	revno := make(map[docKey]int64)
 	info := txnInfo{}
@@ -380,10 +379,10 @@ func (f *flusher) rescan(t *transaction, force bool) (revnos []int64, err error)
 		panic(fmt.Errorf("rescanning transaction in invalid state: %q", t.State))
 	}
 
-	// Iterate in a stable way across all runners. This isn't
-	// strictly required, but reduces the chances of cycles.
+	// docKeys is sorted to support stable iteration across all
+	// runners. This isn't strictly required, but reduces the chances
+	// of cycles.
 	dkeys := t.docKeys()
-	sort.Sort(dkeys)
 
 	tt := t.token()
 	if !force {

--- a/txn/txn_test.go
+++ b/txn/txn_test.go
@@ -107,6 +107,31 @@ func (s *S) TestInsert(c *C) {
 	c.Assert(account.Balance, Equals, 200)
 }
 
+func (s *S) TestInsertStructID(c *C) {
+	type id struct {
+		FirstName string
+		LastName  string
+	}
+	ops := []txn.Op{{
+		C:      "accounts",
+		Id:     id{FirstName: "John", LastName: "Jones"},
+		Assert: txn.DocMissing,
+		Insert: M{"balance": 200},
+	}, {
+		C:      "accounts",
+		Id:     id{FirstName: "Sally", LastName: "Smith"},
+		Assert: txn.DocMissing,
+		Insert: M{"balance": 800},
+	}}
+
+	err := s.runner.Run(ops, "", nil)
+	c.Assert(err, IsNil)
+
+	n, err := s.accounts.Find(nil).Count()
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 2)
+}
+
 func (s *S) TestRemove(c *C) {
 	err := s.accounts.Insert(M{"_id": 0, "balance": 300})
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Removed unnecessary resort of document keys

---

Introduce sortableDocKey

Precompute the nature and sort value for each doc key once instead of each time Less is called. This trades slight additional complexity and memory usage for sort speed. This also paves the way for sorting of struct document keys.

---

Support sorting of struct based document ids
