### PR TITLE
add support for repairCursor command with test coverage

### DIFF
--- a/session.go
+++ b/session.go
@@ -1881,6 +1881,11 @@ func (c *Collection) Pipe(pipeline interface{}) *Pipe {
 	}
 }
 
+// Repair calls the 'repairCursor' command (supported in mongo 2.7.8 and later)
+// and returns an iterator to go through the results.
+// This command requests the server to perform a best-effort attempt to recover
+// all documents from the collection in cases of damaged data files, so it may
+// return multiple copies of the same document.
 func (c *Collection) Repair() *Iter {
 	// Clone session and set it to strong mode so that the server
 	// used for the query may be safely obtained afterwards, if

--- a/session.go
+++ b/session.go
@@ -1881,11 +1881,12 @@ func (c *Collection) Pipe(pipeline interface{}) *Pipe {
 	}
 }
 
-// Repair calls the 'repairCursor' command (supported in mongo 2.7.8 and later)
-// and returns an iterator to go through the results.
-// This command requests the server to perform a best-effort attempt to recover
-// all documents from the collection in cases of damaged data files, so it may
-// return multiple copies of the same document.
+// Repair returns an iterator that goes over all recovered documents in the
+// collection, in a best-effort manner. This is most useful when there are
+// damaged data files. Multiple copies of the same document may be returned
+// by the iterator.
+//
+// Repair is supported in MongoDB 2.7.8 and later.
 func (c *Collection) Repair() *Iter {
 	// Clone session and set it to strong mode so that the server
 	// used for the query may be safely obtained afterwards, if

--- a/session_test.go
+++ b/session_test.go
@@ -3192,6 +3192,48 @@ func (s *S) TestFsync(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (s *S) TestRepairCursor(c *C) {
+	if !s.versionAtLeast(2, 7) {
+		c.Skip("RepairCursor only works on 2.7+")
+	}
+
+	session, err := mgo.Dial("localhost:40001")
+	c.Assert(err, IsNil)
+	defer session.Close()
+	session.SetBatch(2)
+
+	coll := session.DB("mydb").C("mycoll3")
+	err = coll.DropCollection()
+
+	ns := []int{0, 10, 20, 30, 40, 50}
+	for _, n := range ns {
+		coll.Insert(M{"n": n})
+	}
+
+	repairIter := coll.Repair()
+
+	c.Assert(repairIter.Err(), IsNil)
+
+	result := struct{ N int }{}
+	resultCounts := map[int]int{}
+	for repairIter.Next(&result) {
+		resultCounts[result.N]++
+	}
+
+	c.Assert(repairIter.Next(&result), Equals, false)
+	c.Assert(repairIter.Err(), IsNil)
+	c.Assert(repairIter.Close(), IsNil)
+
+	/* Verify that the results of the repair cursor are valid.
+	The repair cursor can return multiple copies
+	of the same document, so to check correctness we only
+	need to verify that at least 1 of each document was returned. */
+
+	for _, key := range ns {
+		c.Assert(resultCounts[key] > 0, Equals, true)
+	}
+}
+
 func (s *S) TestPipeIter(c *C) {
 	if !s.versionAtLeast(2, 1) {
 		c.Skip("Pipe only works on 2.1+")

--- a/session_test.go
+++ b/session_test.go
@@ -3224,10 +3224,10 @@ func (s *S) TestRepairCursor(c *C) {
 	c.Assert(repairIter.Err(), IsNil)
 	c.Assert(repairIter.Close(), IsNil)
 
-	/* Verify that the results of the repair cursor are valid.
-	The repair cursor can return multiple copies
-	of the same document, so to check correctness we only
-	need to verify that at least 1 of each document was returned. */
+	// Verify that the results of the repair cursor are valid.
+	// The repair cursor can return multiple copies
+	// of the same document, so to check correctness we only
+	// need to verify that at least 1 of each document was returned.
 
 	for _, key := range ns {
 		c.Assert(resultCounts[key] > 0, Equals, true)


### PR DESCRIPTION
A new command called "repairCursor" was added to the server in 2.7.8 (see https://jira.mongodb.org/browse/SERVER-15544 for details). We need support for this in the mgo driver so that tools which involve database repair operations (like mongodump) can access it. 
It's implemented as a command which returns a cursor; the server performs a best-effort attempt to recover any data from damaged data files and return the documents it finds on the cursor - so, it could potentially return multiple copies of the same document. I've written the test to account for this behavior.
