### PR TITLE
Enable replica set name assertion in server discovery

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -202,8 +202,8 @@ func (cluster *mongoCluster) syncServer(server *mongoServer) (info *mongoServerI
 	}
 
 	if cluster.setName != "" && result.SetName != cluster.setName {
-		log("SYNC Server ", addr, " not a member of replica set ", cluster.setName)
-		return nil, nil, errors.New(addr + " is not part of " + cluster.setName + " replica set")
+		log("SYNC Server ", addr, " is not a member of replica set ", cluster.setName)
+		return nil, nil, errors.New(addr + " is not a member of replica set " + cluster.setName)
 	}
 
 	if result.IsMaster {
@@ -257,12 +257,6 @@ func (cluster *mongoCluster) addServer(server *mongoServer, info *mongoServerInf
 			cluster.Unlock()
 			server.Close()
 			log("SYNC Discarding unknown server ", server.Addr, " due to partial sync.")
-			return
-		}
-		if cluster.setName != "" && info.SetName != cluster.setName {
-			log("SYNC Discarding ", server.Addr, " not part of ", cluster.setName, " replica set.")
-			cluster.Unlock()
-			server.Close()
 			return
 		}
 		cluster.servers.Add(server)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -814,7 +814,7 @@ func (s *S) TestSyncTimeout(c *C) {
 	// Do something.
 	result := struct{ Ok bool }{}
 	err = session.Run("getLastError", &result)
-	c.Assert(err, Equals, mgo.ErrNoReachableServers)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 	c.Assert(started.Before(time.Now().Add(-timeout)), Equals, true)
 	c.Assert(started.After(time.Now().Add(-timeout*2)), Equals, true)
 }
@@ -832,7 +832,7 @@ func (s *S) TestDialWithTimeout(c *C) {
 	if session != nil {
 		session.Close()
 	}
-	c.Assert(err, Equals, mgo.ErrNoReachableServers)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 	c.Assert(session, IsNil)
 	c.Assert(started.Before(time.Now().Add(-timeout)), Equals, true)
 	c.Assert(started.After(time.Now().Add(-timeout*2)), Equals, true)
@@ -875,7 +875,7 @@ func (s *S) TestSocketTimeoutOnDial(c *C) {
 	started := time.Now()
 
 	session, err := mgo.DialWithTimeout("localhost:40001", timeout)
-	c.Assert(err, Equals, mgo.ErrNoReachableServers)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 	c.Assert(session, IsNil)
 
 	c.Assert(started.Before(time.Now().Add(-timeout)), Equals, true)
@@ -963,8 +963,6 @@ func (s *S) TestDialWithKnownReplSecondary(c *C) {
 	runTest(session, err)
 }
 
-var foreignMemberErrorRegex = ".*not part of.*"
-
 func (s *S) TestDialWithForeignReplPrimary(c *C) {
 	if *fast {
 		c.Skip("-fast")
@@ -977,19 +975,19 @@ func (s *S) TestDialWithForeignReplPrimary(c *C) {
 		ReplicaSetName: "rs1",
 	}
 	_, err := mgo.DialWithInfo(&info)
-	c.Assert(err, ErrorMatches, foreignMemberErrorRegex)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 
 	info.Direct = true
 	_, err = mgo.DialWithInfo(&info)
-	c.Assert(err, ErrorMatches, foreignMemberErrorRegex)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 
 	connectionUrl := "mongodb://localhost:40021/?replicaSet=rs1"
 	_, err = mgo.Dial(connectionUrl)
-	c.Assert(err, ErrorMatches, foreignMemberErrorRegex)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 
 	connectionUrl += "&connect=direct"
 	_, err = mgo.Dial(connectionUrl)
-	c.Assert(err, ErrorMatches, foreignMemberErrorRegex)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 }
 
 func (s *S) TestDialWithForeignReplSecondary(c *C) {
@@ -1004,19 +1002,19 @@ func (s *S) TestDialWithForeignReplSecondary(c *C) {
 		ReplicaSetName: "rs1",
 	}
 	_, err := mgo.DialWithInfo(&info)
-	c.Assert(err, ErrorMatches, foreignMemberErrorRegex)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 
 	info.Direct = true
 	_, err = mgo.DialWithInfo(&info)
-	c.Assert(err, ErrorMatches, foreignMemberErrorRegex)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 
 	connectionUrl := "mongodb://localhost:40022/?replicaSet=rs1"
 	_, err = mgo.Dial(connectionUrl)
-	c.Assert(err, ErrorMatches, foreignMemberErrorRegex)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 
 	connectionUrl += "&connect=direct"
 	_, err = mgo.Dial(connectionUrl)
-	c.Assert(err, ErrorMatches, foreignMemberErrorRegex)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 }
 
 func (s *S) TestDialWithMixedPrimaries(c *C) {
@@ -1091,19 +1089,19 @@ func (s *S) TestDialWithForeignSeeds(c *C) {
 	}
 
 	_, err := mgo.DialWithInfo(&info)
-	c.Assert(err, ErrorMatches, foreignMemberErrorRegex)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 
 	info.Direct = true
 	_, err = mgo.DialWithInfo(&info)
-	c.Assert(err, ErrorMatches, foreignMemberErrorRegex)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 
 	connectionUrl := "mongodb://localhost:40021,localhost:40022/?replicaSet=rs1"
 	_, err = mgo.Dial(connectionUrl)
-	c.Assert(err, ErrorMatches, foreignMemberErrorRegex)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 
 	connectionUrl += "&connect=direct"
 	_, err = mgo.Dial(connectionUrl)
-	c.Assert(err, ErrorMatches, foreignMemberErrorRegex)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 }
 
 func (s *S) TestDialWithUnknownSeeds(c *C) {
@@ -1118,11 +1116,11 @@ func (s *S) TestDialWithUnknownSeeds(c *C) {
 	}
 
 	_, err := mgo.DialWithInfo(&info)
-	c.Assert(err, Equals, mgo.ErrNoReachableServers)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 
 	connectionUrl := "mongodb://localhost:54321,localhost:12345/?replicaSet=rs1"
 	_, err = mgo.Dial(connectionUrl)
-	c.Assert(err, Equals, mgo.ErrNoReachableServers)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 }
 
 func (s *S) TestDirect(c *C) {
@@ -1148,7 +1146,7 @@ func (s *S) TestDirect(c *C) {
 
 	coll := session.DB("mydb").C("mycoll")
 	err = coll.Insert(M{"test": 1})
-	c.Assert(err, Equals, mgo.ErrNoReachableServers)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 
 	// Writing to the local database is okay.
 	coll = session.DB("local").C("mycoll")
@@ -1186,7 +1184,7 @@ func (s *S) TestDirectToUnknownStateMember(c *C) {
 
 	coll := session.DB("mydb").C("mycoll")
 	err = coll.Insert(M{"test": 1})
-	c.Assert(err, Equals, mgo.ErrNoReachableServers)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 
 	// Slave is still reachable.
 	result.Host = ""
@@ -1205,7 +1203,7 @@ func (s *S) TestFailFast(c *C) {
 	started := time.Now()
 
 	_, err := mgo.DialWithInfo(&info)
-	c.Assert(err, Equals, mgo.ErrNoReachableServers)
+	c.Assert(err, ErrorMatches, "no reachable servers")
 
 	c.Assert(started.After(time.Now().Add(-time.Second)), Equals, true)
 }

--- a/server.go
+++ b/server.go
@@ -71,6 +71,7 @@ type mongoServerInfo struct {
 	Mongos         bool
 	Tags           bson.D
 	MaxWireVersion int
+	SetName        string
 }
 
 var defaultServerInfo mongoServerInfo

--- a/session.go
+++ b/session.go
@@ -122,7 +122,7 @@ type Iter struct {
 
 var (
 	ErrNotFound = errors.New("not found")
-	ErrCursor = errors.New("invalid cursor")
+	ErrCursor   = errors.New("invalid cursor")
 )
 
 const defaultPrefetch = 0.25
@@ -226,6 +226,7 @@ func DialWithTimeout(url string, timeout time.Duration) (*Session, error) {
 	mechanism := ""
 	service := ""
 	source := ""
+	setName := ""
 	poolLimit := 0
 	for k, v := range uinfo.options {
 		switch k {
@@ -235,6 +236,8 @@ func DialWithTimeout(url string, timeout time.Duration) (*Session, error) {
 			mechanism = v
 		case "gssapiServiceName":
 			service = v
+		case "replicaSet":
+			setName = v
 		case "maxPoolSize":
 			poolLimit, err = strconv.Atoi(v)
 			if err != nil {
@@ -254,16 +257,17 @@ func DialWithTimeout(url string, timeout time.Duration) (*Session, error) {
 		}
 	}
 	info := DialInfo{
-		Addrs:     uinfo.addrs,
-		Direct:    direct,
-		Timeout:   timeout,
-		Database:  uinfo.db,
-		Username:  uinfo.user,
-		Password:  uinfo.pass,
-		Mechanism: mechanism,
-		Service:   service,
-		Source:    source,
-		PoolLimit: poolLimit,
+		Addrs:          uinfo.addrs,
+		Direct:         direct,
+		Timeout:        timeout,
+		Database:       uinfo.db,
+		Username:       uinfo.user,
+		Password:       uinfo.pass,
+		Mechanism:      mechanism,
+		Service:        service,
+		Source:         source,
+		PoolLimit:      poolLimit,
+		ReplicaSetName: setName,
 	}
 	return DialWithInfo(&info)
 }
@@ -294,8 +298,15 @@ type DialInfo struct {
 
 	// Database is the default database name used when the Session.DB method
 	// is called with an empty name, and is also used during the intial
-	// authenticatoin if Source is unset.
+	// authentication if Source is unset.
 	Database string
+
+	// ReplicaSetName defines the name of the replica set to use for cluster
+	// discovery and monitoring. If specified, at least one of the seed servers
+	// must be a member of the ReplicaSetName replica set - non-members are
+	// ignored. If unspecified, the intended connection is assumed to be either
+	// with individual servers, or one or multiple mongos routers.
+	ReplicaSetName string
 
 	// Source is the database used to establish credentials and privileges
 	// with a MongoDB server. Defaults to the value of Database, if that is
@@ -360,7 +371,7 @@ func DialWithInfo(info *DialInfo) (*Session, error) {
 		}
 		addrs[i] = addr
 	}
-	cluster := newCluster(addrs, info.Direct, info.FailFast, dialer{info.Dial, info.DialServer})
+	cluster := newCluster(addrs, info.Direct, info.FailFast, dialer{info.Dial, info.DialServer}, info.ReplicaSetName)
 	session := newSession(Eventual, cluster, info.Timeout)
 	session.defaultdb = info.Database
 	if session.defaultdb == "" {


### PR DESCRIPTION
Hi Gustavo,

The changes here are meant to address [issue 45](https://github.com/go-mgo/mgo/issues/45). In summary:
- The "DialInfo" struct now accepts a "ReplicaSetName" field that if non-empty, is used to ensure all nodes found during discovery belong to the provided replica set (this is used for sessions established with the "DialWithInfo" function).
- The "DialWithTimeout" function is also updated to check for the replica set name and set the"ReplicaSetName" field.
- Refactored a bit of the tests to check for "ErrNoReachableServers" instead of a string literal.

Important details
- For session establishment, an error is returned if no seed node is part of the replica set. If at least one node is part of the replica set, other non-member seeds are discarded. The usual mechanisms around discovery work as before.
- If no seed node is part of the replica set, an error is returned on dial.
- If no "ReplicaSetName" is provided, session establishment works as before - with the assumption that the servers supplied are either individual mongod servers or mongos routers.

Please take a look and let me know if anything is amiss.

Thanks,
Wisdom.
