### PR TITLE
Fixed small documentation typo on GridFs.Create

### DIFF
--- a/gridfs.go
+++ b/gridfs.go
@@ -131,7 +131,7 @@ func finalizeFile(file *GridFile) {
 //     }
 //     file, err := db.GridFS("fs").Create("myfile.txt")
 //     check(err)
-//     n, err := file.Write([]byte("Hello world!")
+//     n, err := file.Write([]byte("Hello world!"))
 //     check(err)
 //     err = file.Close()
 //     check(err)


### PR DESCRIPTION
Just noticed a syntax problem in a document code example. I thought I'd fix that for you.
