### PR TITLE
Run gofmt and goimports over code

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -262,7 +262,7 @@ func (s *S) TestAuthUpsertUserOtherDBRoles(c *C) {
 	ruser := &mgo.User{
 		Username:     "myruser",
 		Password:     "mypass",
-		OtherDBRoles: map[string][]mgo.Role{"mydb": []mgo.Role{mgo.RoleRead}},
+		OtherDBRoles: map[string][]mgo.Role{"mydb": {mgo.RoleRead}},
 	}
 
 	err = admindb.UpsertUser(ruser)
@@ -936,7 +936,7 @@ func (s *S) TestAuthX509Cred(c *C) {
 	externalDB := session.DB("$external")
 	var x509User mgo.User = mgo.User{
 		Username:     x509Subject,
-		OtherDBRoles: map[string][]mgo.Role{"admin": []mgo.Role{mgo.RoleRoot}},
+		OtherDBRoles: map[string][]mgo.Role{"admin": {mgo.RoleRoot}},
 	}
 	err = externalDB.UpsertUser(&x509User)
 	c.Assert(err, IsNil)

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -518,7 +518,7 @@ var unmarshalItems = []testItemType{
 	// Ignore unsuitable types silently.
 	{map[string]string{"str": "s"},
 		"\x02str\x00\x02\x00\x00\x00s\x00" + "\x10int\x00\x01\x00\x00\x00"},
-	{map[string][]int{"array": []int{5, 9}},
+	{map[string][]int{"array": {5, 9}},
 		"\x04array\x00" + wrapInDoc("\x100\x00\x05\x00\x00\x00"+"\x021\x00\x02\x00\x00\x00s\x00"+"\x102\x00\x09\x00\x00\x00")},
 
 	// Wrong type. Shouldn't init pointer.
@@ -1156,7 +1156,7 @@ var twoWayCrossItems = []crossTypeItem{
 			B, C int
 		}
 	}{struct{ B, C int }{1, 2}},
-		map[string]map[string]int{"a": map[string]int{"b": 1, "c": 2}}},
+		map[string]map[string]int{"a": {"b": 1, "c": 2}}},
 
 	{&struct{ A bson.Symbol }{"abc"}, map[string]string{"a": "abc"}},
 	{&struct{ A bson.Symbol }{"abc"}, map[string][]byte{"a": []byte("abc")}},
@@ -1181,8 +1181,8 @@ var twoWayCrossItems = []crossTypeItem{
 	{&struct{ URL url.URL }{*parseURL("h://e.c/p")}, map[string]string{"url": "h://e.c/p"}},
 
 	// Slices
-	{&struct{ S []int }{[]int{1, 2, 3}}, map[string][]int{"s": []int{1, 2, 3}}},
-	{&struct{ S *[]int }{&[]int{1, 2, 3}}, map[string][]int{"s": []int{1, 2, 3}}},
+	{&struct{ S []int }{[]int{1, 2, 3}}, map[string][]int{"s": {1, 2, 3}}},
+	{&struct{ S *[]int }{&[]int{1, 2, 3}}, map[string][]int{"s": {1, 2, 3}}},
 
 	// Conditionals
 	{&condBool{true}, map[string]bool{"v": true}},
@@ -1196,7 +1196,7 @@ var twoWayCrossItems = []crossTypeItem{
 	{&condStr{}, map[string]string{}},
 	{&condStrNS{"yo"}, map[string]string{"v": "yo"}},
 	{&condStrNS{}, map[string]string{}},
-	{&condSlice{[]string{"yo"}}, map[string][]string{"v": []string{"yo"}}},
+	{&condSlice{[]string{"yo"}}, map[string][]string{"v": {"yo"}}},
 	{&condSlice{}, map[string][]string{}},
 	{&condMap{map[string]int{"k": 1}}, bson.M{"v": bson.M{"k": 1}}},
 	{&condMap{}, map[string][]string{}},
@@ -1248,7 +1248,7 @@ var twoWayCrossItems = []crossTypeItem{
 	{&struct{ B bool }{}, map[string]MyBool{"b": false}},
 
 	// arrays
-	{&struct{ V [2]int }{[...]int{1, 2}}, map[string][2]int{"v": [2]int{1, 2}}},
+	{&struct{ V [2]int }{[...]int{1, 2}}, map[string][2]int{"v": {1, 2}}},
 
 	// zero time
 	{&struct{ V time.Time }{}, map[string]interface{}{"v": time.Time{}}},
@@ -1365,21 +1365,21 @@ type objectIdParts struct {
 }
 
 var objectIds = []objectIdParts{
-	objectIdParts{
+	{
 		bson.ObjectIdHex("4d88e15b60f486e428412dc9"),
 		1300816219,
 		[]byte{0x60, 0xf4, 0x86},
 		0xe428,
 		4271561,
 	},
-	objectIdParts{
+	{
 		bson.ObjectIdHex("000000000000000000000000"),
 		0,
 		[]byte{0x00, 0x00, 0x00},
 		0x0000,
 		0,
 	},
-	objectIdParts{
+	{
 		bson.ObjectIdHex("00000000aabbccddee000001"),
 		0,
 		[]byte{0xaa, 0xbb, 0xcc},

--- a/bson/decode.go
+++ b/bson/decode.go
@@ -1,18 +1,18 @@
 // BSON library for Go
-// 
+//
 // Copyright (c) 2010-2012 - Gustavo Niemeyer <gustavo@niemeyer.net>
-// 
+//
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met: 
-// 
+// modification, are permitted provided that the following conditions are met:
+//
 // 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer. 
+//    list of conditions and the following disclaimer.
 // 2. Redistributions in binary form must reproduce the above copyright notice,
 //    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution. 
-// 
+//    and/or other materials provided with the distribution.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -1,18 +1,18 @@
 // BSON library for Go
-// 
+//
 // Copyright (c) 2010-2012 - Gustavo Niemeyer <gustavo@niemeyer.net>
-// 
+//
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met: 
-// 
+// modification, are permitted provided that the following conditions are met:
+//
 // 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer. 
+//    list of conditions and the following disclaimer.
 // 2. Redistributions in binary form must reproduce the above copyright notice,
 //    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution. 
-// 
+//    and/or other materials provided with the distribution.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -212,7 +212,7 @@ func (e *encoder) addSlice(v reflect.Value) {
 		return
 	}
 	l := v.Len()
-	et  := v.Type().Elem()
+	et := v.Type().Elem()
 	if et == typeDocElem {
 		for i := 0; i < l; i++ {
 			elem := v.Index(i).Interface().(DocElem)
@@ -415,7 +415,7 @@ func (e *encoder) addElem(name string, v reflect.Value, minSize bool) {
 		case time.Time:
 			// MongoDB handles timestamps as milliseconds.
 			e.addElemName('\x09', name)
-			e.addInt64(s.Unix() * 1000 + int64(s.Nanosecond() / 1e6))
+			e.addInt64(s.Unix()*1000 + int64(s.Nanosecond()/1e6))
 
 		case url.URL:
 			e.addElemName('\x02', name)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -910,13 +910,13 @@ func (s *S) TestSocketTimeoutOnInactiveSocket(c *C) {
 func (s *S) TestDialWithReplicaSetName(c *C) {
 	seedLists := [][]string{
 		// rs1 primary and rs2 primary
-		[]string{"localhost:40011", "localhost:40021"},
+		{"localhost:40011", "localhost:40021"},
 		// rs1 primary and rs2 secondary
-		[]string{"localhost:40011", "localhost:40022"},
+		{"localhost:40011", "localhost:40022"},
 		// rs1 secondary and rs2 primary
-		[]string{"localhost:40012", "localhost:40021"},
+		{"localhost:40012", "localhost:40021"},
 		// rs1 secondary and rs2 secondary
-		[]string{"localhost:40012", "localhost:40022"},
+		{"localhost:40012", "localhost:40022"},
 	}
 
 	rs2Members := []string{":40021", ":40022", ":40023"}

--- a/internal/scram/scram.go
+++ b/internal/scram/scram.go
@@ -133,7 +133,7 @@ func (c *Client) Step(in []byte) bool {
 func (c *Client) step1(in []byte) error {
 	if len(c.clientNonce) == 0 {
 		const nonceLen = 6
-		buf := make([]byte, nonceLen + b64.EncodedLen(nonceLen))
+		buf := make([]byte, nonceLen+b64.EncodedLen(nonceLen))
 		if _, err := rand.Read(buf[:nonceLen]); err != nil {
 			return fmt.Errorf("cannot read random SCRAM-SHA-1 nonce from operating system: %v", err)
 		}

--- a/internal/scram/scram_test.go
+++ b/internal/scram/scram_test.go
@@ -4,9 +4,10 @@ import (
 	"crypto/sha1"
 	"testing"
 
+	"strings"
+
 	. "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/internal/scram"
-	"strings"
 )
 
 var _ = Suite(&S{})

--- a/txn/mgo_test.go
+++ b/txn/mgo_test.go
@@ -2,8 +2,8 @@ package txn_test
 
 import (
 	"bytes"
-	"gopkg.in/mgo.v2"
 	. "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
 	"os/exec"
 	"time"
 )

--- a/txn/mgo_test.go
+++ b/txn/mgo_test.go
@@ -2,10 +2,11 @@ package txn_test
 
 import (
 	"bytes"
-	. "gopkg.in/check.v1"
-	"gopkg.in/mgo.v2"
 	"os/exec"
 	"time"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
 )
 
 // ----------------------------------------------------------------------------

--- a/txn/sim_test.go
+++ b/txn/sim_test.go
@@ -2,10 +2,10 @@ package txn_test
 
 import (
 	"flag"
+	. "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
-	. "gopkg.in/check.v1"
 	"math/rand"
 	"time"
 )

--- a/txn/sim_test.go
+++ b/txn/sim_test.go
@@ -2,12 +2,13 @@ package txn_test
 
 import (
 	"flag"
+	"math/rand"
+	"time"
+
 	. "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
-	"math/rand"
-	"time"
 )
 
 var (

--- a/txn/tarjan.go
+++ b/txn/tarjan.go
@@ -1,8 +1,9 @@
 package txn
 
 import (
-	"gopkg.in/mgo.v2/bson"
 	"sort"
+
+	"gopkg.in/mgo.v2/bson"
 )
 
 func tarjanSort(successors map[bson.ObjectId][]bson.ObjectId) [][]bson.ObjectId {

--- a/txn/tarjan_test.go
+++ b/txn/tarjan_test.go
@@ -2,8 +2,8 @@ package txn
 
 import (
 	"fmt"
-	"gopkg.in/mgo.v2/bson"
 	. "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
 )
 
 type TarjanSuite struct{}

--- a/txn/tarjan_test.go
+++ b/txn/tarjan_test.go
@@ -2,6 +2,7 @@ package txn
 
 import (
 	"fmt"
+
 	. "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/bson"
 )


### PR DESCRIPTION
It's fairly standard for Go projects to be formatted according to gofmt.

This pull request also includes the simplifications from `gofmt -s`; the one that shows up is that in a slice or map literal containing literals, the type in the element literals can be omitted. `map[string][]int{"array": []int{5, 9}` to `map[string][]int{"array": {5, 9}` change is a good example, where the `[]int` type is not necessary.
