### PR TITLE
Capitalize ParseURL to make public.

### DIFF
--- a/session.go
+++ b/session.go
@@ -218,7 +218,7 @@ func Dial(url string) (*Session, error) {
 //
 // See SetSyncTimeout for customizing the timeout for the session.
 func DialWithTimeout(url string, timeout time.Duration) (*Session, error) {
-	uinfo, err := parseURL(url)
+	uinfo, err := ParseURL(url)
 	if err != nil {
 		return nil, err
 	}
@@ -428,7 +428,7 @@ type urlInfo struct {
 	options map[string]string
 }
 
-func parseURL(s string) (*urlInfo, error) {
+func ParseURL(s string) (*urlInfo, error) {
 	if strings.HasPrefix(s, "mongodb://") {
 		s = s[10:]
 	}


### PR DESCRIPTION
To prevent us from writing boilerplate code for parsing a Mongo URL (or having to provide the options directly), it would be great to have the ParseURL function be public.

Related issue: https://github.com/cloudpipe/cloudpipe/pull/69
