### PR TITLE
Parse the SSL flag automatically

### DIFF
--- a/session.go
+++ b/session.go
@@ -28,6 +28,7 @@ package mgo
 
 import (
 	"crypto/md5"
+	"crypto/tls"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -242,6 +243,10 @@ func DialWithTimeout(url string, timeout time.Duration) (*Session, error) {
 			poolLimit, err = strconv.Atoi(v)
 			if err != nil {
 				return nil, errors.New("bad value for maxPoolSize: " + v)
+			}
+		case "ssl":
+			dialServer = func(addr *mgo.ServerAddr) (net.Conn, error) {
+				return tls.Dial("tcp", addr.String(), &tls.Config{})
 			}
 		case "connect":
 			if v == "direct" {

--- a/session.go
+++ b/session.go
@@ -229,6 +229,7 @@ func DialWithTimeout(url string, timeout time.Duration) (*Session, error) {
 	source := ""
 	setName := ""
 	poolLimit := 0
+	var dialServer func(addr *ServerAddr) (net.Conn, error) = nil
 	for k, v := range uinfo.options {
 		switch k {
 		case "authSource":
@@ -245,7 +246,7 @@ func DialWithTimeout(url string, timeout time.Duration) (*Session, error) {
 				return nil, errors.New("bad value for maxPoolSize: " + v)
 			}
 		case "ssl":
-			dialServer = func(addr *mgo.ServerAddr) (net.Conn, error) {
+			dialServer = func(addr *ServerAddr) (net.Conn, error) {
 				return tls.Dial("tcp", addr.String(), &tls.Config{})
 			}
 		case "connect":
@@ -273,6 +274,7 @@ func DialWithTimeout(url string, timeout time.Duration) (*Session, error) {
 		Source:         source,
 		PoolLimit:      poolLimit,
 		ReplicaSetName: setName,
+		DialServer:     dialServer,
 	}
 	return DialWithInfo(&info)
 }


### PR DESCRIPTION
This uses the host's root CA set by default, parsing out [the `ssl` option from the connection string](http://docs.mongodb.org/manual/reference/connection-string/#uri.ssl).
