### PR TITLE
Fixed "The dollar ($) prefixed field '$pullAll' in '$pullAll' is not valid for storage" issue

### DIFF
--- a/txn/flusher.go
+++ b/txn/flusher.go
@@ -734,10 +734,10 @@ func (f *flusher) apply(t *transaction, pull map[bson.ObjectId]*transaction) err
 				if d, err = objToDoc(op.Update); err != nil {
 					return err
 				}
-				if d, err = addToDoc(d, "$pullAll", bson.D{{"txn-queue", pullAll}}); err != nil {
+				if d, err = addToDoc(d, "pullAll", bson.D{{"txn-queue", pullAll}}); err != nil {
 					return err
 				}
-				if d, err = addToDoc(d, "$set", bson.D{{"txn-revno", newRevno}}); err != nil {
+				if d, err = addToDoc(d, "set", bson.D{{"txn-revno", newRevno}}); err != nil {
 					return err
 				}
 				chaos("")


### PR DESCRIPTION
Fixed issue that prevented ability to process updates to mongodb documents in v2.6 due to 'The dollar ($) prefixed field '$pullAll' in '$pullAll' is not valid for storage' error, and subsequent error with $set.

It's a simple fix (just removed the $ sign in two places) and it seems to be working for my code now.

Please review and merge back into original v2 if you agree with the changes.

Thanks!
Sadiq.
