### PR TITLE
add support for geoHaystack index

### DIFF
--- a/session.go
+++ b/session.go
@@ -947,15 +947,16 @@ func (db *Database) RemoveUser(user string) error {
 type indexSpec struct {
 	Name, NS         string
 	Key              bson.D
-	Unique           bool   ",omitempty"
-	DropDups         bool   "dropDups,omitempty"
-	Background       bool   ",omitempty"
-	Sparse           bool   ",omitempty"
-	Bits, Min, Max   int    ",omitempty"
-	ExpireAfter      int    "expireAfterSeconds,omitempty"
-	Weights          bson.D ",omitempty"
-	DefaultLanguage  string "default_language,omitempty"
-	LanguageOverride string "language_override,omitempty"
+	Unique           bool    ",omitempty"
+	DropDups         bool    "dropDups,omitempty"
+	Background       bool    ",omitempty"
+	Sparse           bool    ",omitempty"
+	Bits, Min, Max   int     ",omitempty"
+	BucketSize       float64 "bucketSize,omitempty"
+	ExpireAfter      int     "expireAfterSeconds,omitempty"
+	Weights          bson.D  ",omitempty"
+	DefaultLanguage  string  "default_language,omitempty"
+	LanguageOverride string  "language_override,omitempty"
 }
 
 type Index struct {
@@ -975,6 +976,7 @@ type Index struct {
 
 	// Properties for spatial indexes.
 	Bits, Min, Max int
+	BucketSize     float64
 
 	// Properties for text indexes.
 	DefaultLanguage  string
@@ -1170,6 +1172,7 @@ func (c *Collection) EnsureIndex(index Index) error {
 		Bits:             index.Bits,
 		Min:              index.Min,
 		Max:              index.Max,
+		BucketSize:       index.BucketSize,
 		ExpireAfter:      int(index.ExpireAfter / time.Second),
 		Weights:          keyInfo.weights,
 		DefaultLanguage:  index.DefaultLanguage,

--- a/session_test.go
+++ b/session_test.go
@@ -2566,6 +2566,17 @@ var indexTests = []struct {
 	},
 }, {
 	mgo.Index{
+		Key:        []string{"$geoHaystack:loc", "type"},
+		BucketSize: 1,
+	},
+	M{
+		"name":       "loc_geoHaystack_type_1",
+		"key":        M{"loc": "geoHaystack", "type": 1},
+		"ns":         "mydb.mycoll",
+		"bucketSize": 1,
+	},
+}, {
+	mgo.Index{
 		Key:     []string{"$text:a", "$text:b"},
 		Weights: map[string]int{"b": 42},
 	},


### PR DESCRIPTION
As seen [in the manual](http://docs.mongodb.org/manual/tutorial/build-a-geohaystack-index/), the haystack index uses a property called bucketSize, which isn't currently available through this driver. This commit adds the property.

**Note**: I'm not entirely sure if the tag key is actually needed for the `BucketSize` field (i.e. `"bucketSize,omitempty"` vs `",omitempty"`). The [documentation](http://godoc.org/gopkg.in/mgo.v2/bson#Marshal) seems to indicate that the key should be the lowercased field name anyway. But without the key the added test failed. Although, I didn't spend too long setting up the environment and some other, seemingly random, tests failed as well. So it could be that my envrionment is to blame. But then I saw that `DropDups` also specified the tag key, so I'm not really sure either way.
