### PR TITLE
Avoid Setter creation if value is nil

### DIFF
--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -770,8 +770,17 @@ func (s *S) TestUnmarshalAllItemsWithPtrSetter(c *C) {
 				}
 			} else {
 				expected := item.obj.(bson.M)["_"]
-				c.Assert(field, NotNil, Commentf("Pointer not initialized (%#v)", expected))
-				c.Assert(field.received, DeepEquals, expected)
+				if expected == nil {
+					if i == 0 {
+						c.Assert(field, IsNil, Commentf("Nill expected. Got (%#v).", field))
+					} else {
+						// Field is not nil since it's a value.
+						c.Assert(field.received, IsNil, Commentf("Nill expected. Got (%#v).", field.received))
+					}
+				} else {
+					c.Assert(field, NotNil, Commentf("Pointer not initialized (%#v).", expected))
+					c.Assert(field.received, DeepEquals, expected)
+				}
 			}
 		}
 	}
@@ -845,6 +854,20 @@ func (s *S) TestUnmarshalSetterSetZero(c *C) {
 	value, ok := m["field"]
 	c.Assert(ok, Equals, true)
 	c.Assert(value, IsNil)
+}
+
+func (s *S) TestUnmarshalNilSetter(c *C) {
+	type container struct {
+		S *setterType
+	}
+	var in, out container
+
+	data, err := bson.Marshal(&in)
+	c.Assert(err, IsNil)
+
+	err = bson.Unmarshal(data, &out)
+	c.Assert(err, IsNil)
+	c.Assert(out.S, IsNil)
 }
 
 // --------------------------------------------------------------------------

--- a/bson/decode.go
+++ b/bson/decode.go
@@ -543,6 +543,11 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 		return true
 	}
 
+	if in == nil {
+		out.Set(reflect.Zero(outt))
+		return true
+	}
+
 	if setter := getSetter(outt, out); setter != nil {
 		err := setter.SetBSON(Raw{kind, d.in[start:d.i]})
 		if err == SetZero {
@@ -556,11 +561,6 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 			panic(err)
 		}
 		return false
-	}
-
-	if in == nil {
-		out.Set(reflect.Zero(outt))
-		return true
 	}
 
 	outk := outt.Kind()


### PR DESCRIPTION
Check for nil is now done before the code that handles `Setter` interface.
Otherwise Setter instance is created even if actual value is nil, which is quite unexpected.

Fixed scenario is illustrated in `TestUnmarshalNilSetter`.
I had to modify `TestUnmarshalAllItemsWithPtrSetter` in an awkward way though.

After implementing this change I found out that `SetBSON` can return `SetZero`. But I personally do not understand how creating a `Setter` instance can be useful if we unmarshal `nil` value.
Will appreciate if an example is given.
It also makes `SetBSON` method implementation a bit gross IMO since you have to write code like

``` go
if raw.Kind == 0x0A { // Nil value.
  return bson.SetZero
}
```
