### PR TITLE
Check PurgeMissing iterator errors & other minor fixes

### DIFF
--- a/txn/txn.go
+++ b/txn/txn.go
@@ -417,6 +417,9 @@ func (r *Runner) PurgeMissing(collections ...string) error {
 				return fmt.Errorf("error purging missing transaction %s: %v", txnId.Hex(), err)
 			}
 		}
+		if err := iter.Close(); err != nil {
+			return fmt.Errorf("transaction queue iteration error for collection %s: %v", collection, err)
+		}
 		colls[collection] = true
 	}
 
@@ -441,6 +444,9 @@ func (r *Runner) PurgeMissing(collections ...string) error {
 		if err != nil {
 			return fmt.Errorf("error purging missing transaction %s: %v", txnId.Hex(), err)
 		}
+	}
+	if err := iter.Close(); err != nil {
+		return fmt.Errorf("transaction stash iteration error: %v", err)
 	}
 
 	return nil

--- a/txn/txn.go
+++ b/txn/txn.go
@@ -395,7 +395,6 @@ func (r *Runner) PurgeMissing(collections ...string) error {
 	}
 
 	found := make(map[bson.ObjectId]bool)
-	colls := make(map[string]bool)
 
 	sort.Strings(collections)
 	for _, collection := range collections {
@@ -420,7 +419,6 @@ func (r *Runner) PurgeMissing(collections ...string) error {
 		if err := iter.Close(); err != nil {
 			return fmt.Errorf("transaction queue iteration error for collection %s: %v", collection, err)
 		}
-		colls[collection] = true
 	}
 
 	type StashTRef struct {

--- a/txn/txn_test.go
+++ b/txn/txn_test.go
@@ -534,7 +534,7 @@ func (s *S) TestPurgeMissing(c *C) {
 	err = s.runner.Run(ops2, "", nil)
 	c.Assert(err, ErrorMatches, "cannot find transaction .*")
 
-	c.Logf("---- Puring missing transactions")
+	c.Logf("---- Purging missing transactions")
 	err = s.runner.PurgeMissing("accounts")
 	c.Assert(err, IsNil)
 

--- a/txn/txn_test.go
+++ b/txn/txn_test.go
@@ -531,7 +531,7 @@ func (s *S) TestPurgeMissing(c *C) {
 
 	again := bson.NewObjectId()
 	c.Logf("---- Running ops2 again under transaction %q, to fail for missing transaction", again.Hex())
-	err = s.runner.Run(ops2, "", nil)
+	err = s.runner.Run(ops2, again, nil)
 	c.Assert(err, ErrorMatches, "cannot find transaction .*")
 
 	c.Logf("---- Purging missing transactions")


### PR DESCRIPTION
The main fix here is to have PurgeMissing check for pipeline iteration errors. Not having these meant that PurgeMissing was silently failing in a production recovery situation (due to pipeline result size limits under MongoDB 2.4). A later PR will propose a change to PurgeMissing to avoid the pipeline size limit issue.

The other commits are all tiny fixes to PurgeMissing and TestPurgeMissing.
