### PR TITLE
Guard against empty/malformed transaction ids in storage.

### DIFF
--- a/txn/flusher.go
+++ b/txn/flusher.go
@@ -220,6 +220,10 @@ var errPreReqs = fmt.Errorf("transaction has pre-requisites and force is false")
 // is false, errPreReqs will be returned. Otherwise, the current
 // tip revision numbers for all the documents are returned.
 func (f *flusher) prepare(t *transaction, force bool) (revnos []int64, err error) {
+	if !t.valid() {
+		return nil, fmt.Errorf("invalid transaction %s", t.Id)
+	}
+
 	if t.State != tpreparing {
 		return f.rescan(t, force)
 	}
@@ -375,6 +379,10 @@ func (f *flusher) unstashToken(tt token, dkey docKey) error {
 }
 
 func (f *flusher) rescan(t *transaction, force bool) (revnos []int64, err error) {
+	if !t.valid() {
+		return fmt.Errorf("invalid transaction %s", t.Id)
+	}
+
 	f.debugf("Rescanning %s", t)
 	if t.State != tprepared {
 		panic(fmt.Errorf("rescanning transaction in invalid state: %q", t.State))
@@ -680,6 +688,10 @@ func (f *flusher) checkpoint(t *transaction, revnos []int64) error {
 }
 
 func (f *flusher) apply(t *transaction, pull map[bson.ObjectId]*transaction) error {
+	if !t.valid() {
+		return fmt.Errorf("invalid transaction %s", t.Id)
+	}
+
 	f.debugf("Applying transaction %s", t)
 	if t.State != tapplying {
 		panic(fmt.Errorf("applying transaction in invalid state: %q", t.State))

--- a/txn/txn.go
+++ b/txn/txn.go
@@ -78,6 +78,10 @@ func (t *transaction) String() string {
 	return string(t.token())
 }
 
+func (t *transaction) valid() bool {
+	return t.Id.Valid()
+}
+
 func (t *transaction) done() bool {
 	return t.State == tapplied || t.State == taborted
 }
@@ -85,6 +89,9 @@ func (t *transaction) done() bool {
 func (t *transaction) token() token {
 	if t.Nonce == "" {
 		panic("transaction has no nonce")
+	}
+	if !t.valid() {
+		panic("transaction is not valid")
 	}
 	return tokenFor(t)
 }
@@ -113,6 +120,8 @@ NextOp:
 // is composed by t's id and a nonce. If t already has
 // a nonce assigned to it, it will be used, otherwise
 // a new nonce will be generated.
+//
+// This function assumes that the transaction is valid.
 func tokenFor(t *transaction) token {
 	nonce := t.Nonce
 	if nonce == "" {


### PR DESCRIPTION
A panic may result from a transaction document that contains an invalid `Id`. This is not normally expected behavior but could happen if the disk filled up, for example.

My solution is to add a `txn/transaction.valid()` method, which is checked at the top of methods that otherwise assume the `Id` is valid (creating tokens for them makes this assumption).

Its possible that there are better ways to handle these errors. If so, please advise.

Encountered this issue in the wild (LP:#1452251).
