### PR TITLE
Add test for connections statistics after syncing

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1655,3 +1655,24 @@ func (s *S) TestSelectServersWithMongos(c *C) {
 		c.Fatal("Uh?")
 	}
 }
+
+func (s *S) TestConnsStatsAfterSyncServers(c *C) {
+	if *fast {
+		c.Skip("-fast")
+	}
+
+	session, err := mgo.Dial("localhost:40001")
+	c.Assert(err, IsNil)
+	defer session.Close()
+
+	stats := mgo.GetStats()
+	c.Assert(stats.MasterConns, Equals, 1)
+	c.Assert(stats.SlaveConns, Equals, 0)
+
+	// Waiting for syncServersIteration (syncServersDelay + 1 second to be sure)
+	time.Sleep(31e9)
+
+	stats = mgo.GetStats()
+	c.Assert(stats.MasterConns, Equals, 1)
+	c.Assert(stats.SlaveConns, Equals, 0)
+}


### PR DESCRIPTION
This is a test case for issue #83. Perhaps there is a better way to run syncServersLoop rather than sleep.
