### PR TITLE
Support encoding byte arrays in structs

### DIFF
--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -1268,6 +1268,7 @@ var twoWayCrossItems = []crossTypeItem{
 
 	// arrays
 	{&struct{ V [2]int }{[...]int{1, 2}}, map[string][2]int{"v": [2]int{1, 2}}},
+	{&struct{ V [2]byte }{[...]byte{1, 2}}, map[string][2]byte{"v": [2]byte{1, 2}}},
 
 	// zero time
 	{&struct{ V time.Time }{}, map[string]interface{}{"v": time.Time{}}},

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -365,7 +365,17 @@ func (e *encoder) addElem(name string, v reflect.Value, minSize bool) {
 		et := v.Type().Elem()
 		if et.Kind() == reflect.Uint8 {
 			e.addElemName('\x05', name)
-			e.addBinary('\x00', v.Slice(0, v.Len()).Interface().([]byte))
+			if v.CanAddr() {
+				e.addBinary('\x00', v.Slice(0, v.Len()).Interface().([]byte))
+			} else {
+				n := v.Len()
+				e.addInt32(int32(n))
+				e.addBytes('\x00')
+				for i := 0; i < n; i++ {
+					el := v.Index(i)
+					e.addBytes(byte(el.Uint()))
+				}
+			}
 		} else {
 			e.addElemName('\x04', name)
 			e.addDoc(v)


### PR DESCRIPTION
Indexes each element of the array rather than allocating a slice to
copy the array into as in #74.

Fixes #73.
