### PR TITLE
Replace bad not found check in Update.

### DIFF
--- a/session.go
+++ b/session.go
@@ -2174,6 +2174,10 @@ func (err *LastError) Error() string {
 	return err.Err
 }
 
+func (err *LastError) Found() bool {
+	return err.N > 0
+}
+
 type queryError struct {
 	Err           string "$err"
 	ErrMsg        string
@@ -2230,7 +2234,7 @@ func (c *Collection) Insert(docs ...interface{}) error {
 //
 func (c *Collection) Update(selector interface{}, update interface{}) error {
 	lerr, err := c.writeQuery(&updateOp{c.FullName, selector, update, 0})
-	if err == nil && lerr != nil && !lerr.UpdatedExisting {
+	if err == nil && lerr != nil && !lerr.Found() {
 		return ErrNotFound
 	}
 	return err


### PR DESCRIPTION
`Update` was assuming that, if no document was updated, the selector query wasn't matching anything, thus returning `ErrNotFound`. That's wrong, because it can happen that the selector matches but then the new updated value is jus the same as the old one, in which case `nModified` is 0 even if the query is successful.

Now `LastError` has a `Found` method that returns true if `result.N` is greater than zero. `Update` checks that method instead of `UpdatedExisting`.

I haven't added a test nor run the existing ones because apparently they need a quite complex previous setup in your machine. Sorry for that.
