### PR TITLE
add Extra field to CollectionInfo

### DIFF
--- a/session.go
+++ b/session.go
@@ -2386,6 +2386,9 @@ type CollectionInfo struct {
 	Capped   bool
 	MaxBytes int
 	MaxDocs  int
+
+	// Extra holds non-standard or newly-added options.
+	Extra bson.M
 }
 
 // Create explicitly creates the c collection with details of info.
@@ -2416,6 +2419,9 @@ func (c *Collection) Create(info *CollectionInfo) error {
 	}
 	if info.ForceIdIndex {
 		cmd = append(cmd, bson.DocElem{"autoIndexId", true})
+	}
+	for key, value := range info.Extra {
+		cmd = append(cmd, bson.DocElem{key, value})
 	}
 	return c.Database.Run(cmd, nil)
 }
@@ -4188,7 +4194,7 @@ func (c *Collection) writeCommand(socket *mongoSocket, safeOp *queryOp, op inter
 	debugf("Write command result: %#v (err=%v)", result, err)
 	lerr = &LastError{
 		UpdatedExisting: result.N > 0 && len(result.Upserted) == 0,
-		N: result.N,
+		N:               result.N,
 	}
 	if len(result.Upserted) > 0 {
 		lerr.UpsertedId = result.Upserted[0].Id


### PR DESCRIPTION
This is to allow setting options which provided only by alternative implementations of MongoDB, mainly TokuMX: http://docs.tokutek.com/tokumx/tokumx-collection-index-options.html
