### PR TITLE
Add functions to expose cursorID and batch size of iterators

### DIFF
--- a/session.go
+++ b/session.go
@@ -3356,6 +3356,22 @@ func (iter *Iter) All(result interface{}) error {
 	return iter.Close()
 }
 
+// CursorID retrieves the cursor ID associated with the iterator.
+//
+// The CursorID is only set once the first document is retrieved from the result
+// set.
+func (iter *Iter) CursorID() int64 {
+	return iter.op.cursorId
+}
+
+// SetBatch sets the batch size used for this iterator when fetching documents from the
+// database.
+func (iter *Iter) SetBatch(n int) {
+	iter.m.Lock()
+	iter.op.limit = int32(n)
+	iter.m.Unlock()
+}
+
 // All works like Iter.All.
 func (q *Query) All(result interface{}) error {
 	return q.Iter().All(result)


### PR DESCRIPTION
Hi, I'm working on a mongo proxy server that uses mgo to communicate with MongoDB, and needed the ability to be able to separate the find and getMore operations into their distinct operations (rather than how Iterators automatically call getMore once the current batch is exhausted). I didn't see any way of manually emulating a getMore operation besides calling `NewIter` on a collection with an existing cursor ID, so the changes are assuming that method.

The first change is a function that exposes an Iterator's cursor ID, as currently you can create a new Iterator with an existing cursor ID, but no way to retrieve the cursor ID from an existing Iterator object. The second change is a function to set a batch size per Iterator, as creating an Iterator with NewIter doesn't let the user set the batch size, unlike when an Iterator is created with a Query or a Pipe.
