### PR TITLE
Minor documentation fix

### DIFF
--- a/session.go
+++ b/session.go
@@ -205,6 +205,7 @@ const defaultPrefetch = 0.25
 //        Defines the service name to use when authenticating with the GSSAPI
 //        mechanism. Defaults to "mongodb".
 //
+//
 //     maxPoolSize=<limit>
 //
 //        Defines the per-server socket pool limit. Defaults to 4096.

--- a/session.go
+++ b/session.go
@@ -174,6 +174,19 @@ const defaultPrefetch = 0.25
 //         must be relaxed to Monotonic or Eventual via SetMode.
 //
 //
+//	   connect=replicaSet
+//
+//		   Equivalent to the default connection behavior, but is a valid
+//		   connection option that will not cause an error to be thrown.
+//
+//
+//	   replicaSet=<setname>
+//
+//		   Defines the set name for the topology being monitored, and informs the
+//		   automatic server discovery logic that the topology being monitored is
+//		   a replica set.
+//
+//
 //     authSource=<db>
 //
 //         Informs the database used to establish credentials and privileges


### PR DESCRIPTION
Just a little bit of missing documentation I came across while reading through the connection-string-parsing logic.
