### PR TITLE
bson: reading json struct tag if bson tag is missing

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -600,6 +600,9 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 		info := fieldInfo{Num: i}
 
 		tag := field.Tag.Get("bson")
+		if tag == "" {
+			tag = field.Tag.Get("json")
+		}
 		if tag == "" && strings.Index(string(field.Tag), ":") < 0 {
 			tag = string(field.Tag)
 		}

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -993,6 +993,12 @@ type condMap struct {
 type namedCondStr struct {
 	V string "myv,omitempty"
 }
+type jsonNamedCondStr struct {
+	V string `json:"myv,omitempty"`
+}
+type jsonOmitNamedCondStr struct {
+	V string `bson:"myv,omitempty", json:"-"`
+}
 type condTime struct {
 	V time.Time ",omitempty"
 }
@@ -1260,6 +1266,10 @@ var twoWayCrossItems = []crossTypeItem{
 
 	{&namedCondStr{"yo"}, map[string]string{"myv": "yo"}},
 	{&namedCondStr{}, map[string]string{}},
+
+	{&jsonNamedCondStr{"yo"}, map[string]string{"myv": "yo"}},
+	{&jsonNamedCondStr{}, map[string]string{}},
+	{&jsonOmitNamedCondStr{"yo"}, map[string]string{"myv": "yo"}},
 
 	{&shortInt{1}, map[string]interface{}{"v": 1}},
 	{&shortInt{1 << 30}, map[string]interface{}{"v": 1 << 30}},


### PR DESCRIPTION
This is a very small PR but for sure very controversial, the goal is try to avoid add more tags to the fields, reading the `json` struct tag if the `bson` one is missing. 

I am pretty sure that many projects using mgo and having also json serialzable structs, are like: 

``` go
type Person struct {
    Name              string `bson:",omitempty" json:",omitempty"`
    FullName          string `bson:"full_name,omitempty" json:"full_name,omitempty"`
    Description       string `bson:",omitempty" json:",omitempty"`
}
```

This is really annoying because in many cases is expected to have the same snake cases names in a json and also in the mongo document, also could be a source of bugs due to the requirement of the duplicate tags.
