### PR TITLE
Add primitive decimal support to mgo

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -402,6 +402,13 @@ type DBPointer struct {
 	Id        ObjectId
 }
 
+// Uint64x2 is a struct that represents a 128 bit uint and is used
+// for marshaling, parsing, and testing the BSON decimal type
+type Uint64x2 struct {
+	Low uint64
+	High uint64
+}
+
 const initialBufferSize = 64
 
 func handleErr(err *error) {

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -40,6 +40,7 @@ import (
 
 	. "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2-unstable/bson"
+	"gopkg.in/mgo.v2-unstable/decimal"
 	"gopkg.in/yaml.v2"
 )
 
@@ -123,6 +124,8 @@ func (s *S) TestUnmarshalSampleItems(c *C) {
 // length and last \x00 from the document. wrapInDoc() computes them.
 // Note that all of them should be supported as two-way conversions.
 
+var dcml, _ = decimal.Parse("0.1")
+
 var allItems = []testItemType{
 	{bson.M{},
 		""},
@@ -169,6 +172,8 @@ var allItems = []testItemType{
 		"\x12_\x00\x02\x01\x00\x00\x00\x00\x00\x00"},
 	{bson.M{"_": int64(258 << 32)},
 		"\x12_\x00\x00\x00\x00\x00\x02\x01\x00\x00"},
+	{bson.M{"_": dcml},
+		"\x13_\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x3e\x30"},
 	{bson.M{"_": bson.MaxKey},
 		"\x7F_\x00"},
 	{bson.M{"_": bson.MinKey},
@@ -1687,4 +1692,213 @@ func (s *S) BenchmarkUnmarshalRaw(c *C) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+// --------------------------------------------------------------------------
+// Tests for parsing and marshaling decimals.
+
+// makeManyString returns a concatenation of s, length times
+func makeManyString(s string, length int) string {
+	var ret string;
+	for i := 0; i < length; i++ {
+		ret += s
+	}
+	return ret
+}
+
+func (s *S) TestDecimalStringInfinity(c *C) {
+	positiveInfinity := bson.Dec128ToDecimal(bson.Uint64x2{0, 0x7800000000000000})
+	negativeInfinity := bson.Dec128ToDecimal(bson.Uint64x2{0, 0xf800000000000000})
+	c.Assert(positiveInfinity, Equals, "Inf")
+	c.Assert(negativeInfinity, Equals, "-Inf")
+}
+
+func (s *S) TestDecimalStringNaN(c *C) {
+	pNaN := bson.Dec128ToDecimal(bson.Uint64x2{0, 0x7c00000000000000})
+	nNaN := bson.Dec128ToDecimal(bson.Uint64x2{0, 0xfc00000000000000})
+	psNaN := bson.Dec128ToDecimal(bson.Uint64x2{0, 0x7e00000000000000})
+	nsNaN := bson.Dec128ToDecimal(bson.Uint64x2{0, 0xfe00000000000000})
+	payloadNaN := bson.Dec128ToDecimal(bson.Uint64x2{12, 0x7e00000000000000})
+	c.Assert(pNaN, Equals, "NaN")
+	c.Assert(nNaN, Equals, "NaN")
+	c.Assert(psNaN, Equals, "NaN")
+	c.Assert(nsNaN, Equals, "NaN")
+	c.Assert(payloadNaN, Equals, "NaN")
+}
+
+func (s *S) TestDecimalStringRegular(c *C) {
+	one := bson.Dec128ToDecimal(bson.Uint64x2{0x0000000000000001, 0x3040000000000000})
+	// 10E-1
+	oneShift := bson.Dec128ToDecimal(bson.Uint64x2{0x000000000000000a, 0x303e000000000000})
+	zero := bson.Dec128ToDecimal(bson.Uint64x2{0x0000000000000000, 0x3040000000000000})
+	two  := bson.Dec128ToDecimal(bson.Uint64x2{0x0000000000000002, 0x3040000000000000})
+	negativeOne := bson.Dec128ToDecimal(bson.Uint64x2{0x0000000000000001, 0xb040000000000000})
+	negativeZero := bson.Dec128ToDecimal(bson.Uint64x2{0x0000000000000000, 0xb040000000000000})
+	// 0.1
+	tenth := bson.Dec128ToDecimal(bson.Uint64x2{0x0000000000000001, 0x303e000000000000})
+	// 0.001234
+	smallestRegular := bson.Dec128ToDecimal(bson.Uint64x2{0x00000000000004d2, 0x3034000000000000})
+	// 12345789012
+	largestRegular  := bson.Dec128ToDecimal(bson.Uint64x2{0x0000001cbe991a14, 0x3040000000000000})
+	// 0.00123400000
+	trailingZeros := bson.Dec128ToDecimal(bson.Uint64x2{0x00000000075aef40, 0x302a000000000000})
+	// 0.1234567890123456789012345678901234
+	allDigits := bson.Dec128ToDecimal(bson.Uint64x2{0xde825cd07e96aff2, 0x2ffc3cde6fff9732})
+	c.Assert(one, Equals, "1")
+	c.Assert(oneShift, Equals, "1.0")
+	c.Assert(zero, Equals, "0")
+	c.Assert(two , Equals, "2")
+	c.Assert(negativeOne, Equals, "-1")
+	c.Assert(negativeZero, Equals, "-0")
+	c.Assert(tenth, Equals, "0.1")
+	c.Assert(smallestRegular, Equals, "0.001234")
+	c.Assert(largestRegular , Equals, "123456789012")
+	c.Assert(trailingZeros, Equals, "0.00123400000")
+	c.Assert(allDigits, Equals, "0.1234567890123456789012345678901234")
+}
+
+func (s *S) TestDecimalStringScientific(c *C) {
+	// 1.000000000000000000000000000000000E+6144
+	huge := bson.Dec128ToDecimal(bson.Uint64x2{0x38c15b0a00000000, 0x5ffe314dc6448d93})
+	// 1E-6176
+	tiny := bson.Dec128ToDecimal(bson.Uint64x2{0x0000000000000001, 0x0000000000000000})
+	// -1E-6176i
+	negTiny := bson.Dec128ToDecimal(bson.Uint64x2{0x0000000000000001, 0x8000000000000000})
+	// 9.999987654321E+112
+	large := bson.Dec128ToDecimal(bson.Uint64x2{0x000009184db63eb1, 0x3108000000000000})
+	// 9.999999999999999999999999999999999E+6144
+	largest := bson.Dec128ToDecimal(bson.Uint64x2{0x378d8e63ffffffff, 0x5fffed09bead87c0})
+	// 9.999999999999999999999999999999999E-6143
+	tiniest := bson.Dec128ToDecimal(bson.Uint64x2{0x378d8e63ffffffff, 0x0001ed09bead87c0})
+	// 5.192296858534827628530496329220095E+33
+	fullHouse := bson.Dec128ToDecimal(bson.Uint64x2{0xffffffffffffffff, 0x3040ffffffffffff})
+	c.Assert(huge, Equals, "1.000000000000000000000000000000000E+6144")
+	c.Assert(tiny, Equals, "1E-6176")
+	c.Assert(negTiny, Equals, "-1E-6176")
+	c.Assert(large, Equals, "9.999987654321E+112")
+	c.Assert(largest, Equals, "9.999999999999999999999999999999999E+6144")
+	c.Assert(tiniest, Equals, "9.999999999999999999999999999999999E-6143")
+	c.Assert(fullHouse, Equals, "5192296858534827628530496329220095")
+}
+
+func (s *S) TestDecimalStringZeros(c *C) {
+	// 0
+	zero := bson.Dec128ToDecimal(bson.Uint64x2{0x0000000000000000, 0x3040000000000000})
+	// 0E+300
+	posExpZero := bson.Dec128ToDecimal(bson.Uint64x2{0x0000000000000000, 0x3298000000000000})
+	// 0E-600
+	negExpZero := bson.Dec128ToDecimal(bson.Uint64x2{0x0000000000000000, 0x2b90000000000000})
+	c.Assert(zero, Equals, "0")
+	c.Assert(posExpZero, Equals, "0E+300")
+	c.Assert(negExpZero, Equals, "0E-600")
+}
+
+func (s *S) TestDecimalFromStringNaN(c *C) {
+	c.Assert(bson.DecimalToDec128("NaN"), Equals, bson.Uint64x2{0x0000000000000000, 0x7c00000000000000})
+	c.Assert(bson.DecimalToDec128("-NaN"), Equals, bson.Uint64x2{0x0000000000000000, 0x7c00000000000000})
+}
+
+func (s *S) TestDecimalFromStringInfinity(c *C) {
+	c.Assert(bson.DecimalToDec128("Infinity"),
+		     Equals, bson.Uint64x2{0x0000000000000000, 0x7800000000000000})
+	c.Assert(bson.DecimalToDec128("-Infinity"),
+			 Equals, bson.Uint64x2{0x0000000000000000, 0xf800000000000000})
+}
+
+func (s *S) TestDecimalFromStringSimple(c *C) {
+	one := bson.DecimalToDec128("1")
+	negativeOne := bson.DecimalToDec128("-1")
+	zero := bson.DecimalToDec128("0")
+	negativeZero := bson.DecimalToDec128("-0")
+	number := bson.DecimalToDec128("12345678901234567")
+	numberTwo := bson.DecimalToDec128("989898983458")
+	negativeNumber := bson.DecimalToDec128("-12345678901234567")
+	fractionalNumber := bson.DecimalToDec128("0.12345")
+	leadingZero := bson.DecimalToDec128("0.0012345")
+	leadingInsignificantZeros := bson.DecimalToDec128("00012345678901234567")
+	c.Assert(one, Equals, bson.Uint64x2{0x0000000000000001, 0x3040000000000000})
+	c.Assert(negativeOne, Equals, bson.Uint64x2{0x0000000000000001, 0xb040000000000000})
+	c.Assert(zero, Equals, bson.Uint64x2{0x0000000000000000, 0x3040000000000000})
+	c.Assert(negativeZero, Equals, bson.Uint64x2{0x0000000000000000, 0xb040000000000000})
+	c.Assert(number, Equals, bson.Uint64x2{0x002bdc545d6b4b87, 0x3040000000000000})
+	c.Assert(numberTwo, Equals, bson.Uint64x2{0x000000e67a93c822, 0x3040000000000000})
+	c.Assert(negativeNumber, Equals, bson.Uint64x2{0x002bdc545d6b4b87, 0xb040000000000000})
+	c.Assert(fractionalNumber, Equals, bson.Uint64x2{0x0000000000003039, 0x3036000000000000})
+	c.Assert(leadingZero, Equals, bson.Uint64x2{0x0000000000003039, 0x3032000000000000})
+	c.Assert(leadingInsignificantZeros, Equals, bson.Uint64x2{0x002bdc545d6b4b87, 0x3040000000000000})
+}
+
+func (s *S) TestDecimalFromStringLarge(c *C) {
+	large := bson.DecimalToDec128("12345689012345789012345")
+	allDigits := bson.DecimalToDec128("1234567890123456789012345678901234")
+	largest := bson.DecimalToDec128("9999999999999999999999999999999999" + makeManyString("0", 6111))
+	tiniest := bson.DecimalToDec128("0." + makeManyString("0", 6142) + "9999999999999999999999999999999999")
+	fullHouse := bson.DecimalToDec128("5192296858534827628530496329220095")
+
+	c.Assert(large, Equals, bson.Uint64x2{0x42da3a76f9e0d979, 0x304000000000029d})
+	c.Assert(allDigits, Equals, bson.Uint64x2{0xde825cd07e96aff2, 0x30403cde6fff9732})
+	c.Assert(largest, Equals, bson.Uint64x2{0x378d8e63ffffffff, 0x5fffed09bead87c0})
+	c.Assert(tiniest, Equals, bson.Uint64x2{0x378d8e63ffffffff, 0x0001ed09bead87c0})
+	c.Assert(fullHouse, Equals, bson.Uint64x2{0xffffffffffffffff, 0x3040ffffffffffff})
+}
+
+func (s *S) TestDecimalFromStringNormalization(c *C) {
+	trailingZeros := bson.DecimalToDec128("1000000000000000000000000000000000000000")
+	oneNormalize := bson.DecimalToDec128("10000000000000000000000000000000000")
+	noNormalize := bson.DecimalToDec128("1000000000000000000000000000000000")
+	aDisaster := bson.DecimalToDec128("10000000000000000000000000000000000000000000000000000000000000000000")
+
+	zero := bson.DecimalToDec128("0." + makeManyString("0", 6176) + "1")
+
+	c.Assert(trailingZeros, Equals, bson.Uint64x2{0x38c15b0a00000000, 0x304c314dc6448d93})
+	c.Assert(oneNormalize, Equals, bson.Uint64x2{0x38c15b0a00000000, 0x3042314dc6448d93})
+	c.Assert(noNormalize, Equals, bson.Uint64x2{0x38c15b0a00000000, 0x3040314dc6448d93})
+	c.Assert(aDisaster, Equals, bson.Uint64x2{0x38c15b0a00000000, 0x3084314dc6448d93})
+	c.Assert(zero, Equals, bson.Uint64x2{0x0000000000000000, 0x0000000000000000})
+}
+
+func (s *S) TestDecimalFromStringZeros(c *C) {
+	zero := bson.DecimalToDec128("0")
+	negativeZero := bson.DecimalToDec128("-0")
+
+	c.Assert(zero, Equals, bson.Uint64x2{0x0000000000000000, 0x3040000000000000})
+	c.Assert(negativeZero, Equals, bson.Uint64x2{0x0000000000000000, 0xb040000000000000})
+}
+
+func (s *S) TestDecimalFromStringRound(c *C) {
+	truncate := bson.DecimalToDec128("0." + makeManyString("0", 6175) + "10")
+	up := bson.DecimalToDec128("0." + makeManyString("0", 6175) + "15")
+	checkTieUp := bson.DecimalToDec128("0." + makeManyString("0", 6175) + "251")
+	checkTieTrunc := bson.DecimalToDec128("0." + makeManyString("0", 6175) + "250")
+
+	extraDigitUp := bson.DecimalToDec128("10000000000000000000000000000000006")
+	extraDigitDown := bson.DecimalToDec128("10000000000000000000000000000000003")
+	extraDigitTie := bson.DecimalToDec128("10000000000000000000000000000000005")
+	extraDigitTieBreak := bson.DecimalToDec128("100000000000000000000000000000000051")
+
+	tooBig := bson.DecimalToDec128("10000000000000000000000000000000006" + makeManyString("0", 6111))
+
+	largestBinary := bson.DecimalToDec128("12980742146337069071326240823050239")
+
+	roundPropagate := bson.DecimalToDec128("99999999999999999999999999999999999")
+	roundPropagateLarge := bson.DecimalToDec128("9999999999999999999999999999999999999999999999999999999999999999999")
+	notInf := bson.DecimalToDec128("9999999999999999999999999999999999" + makeManyString("0", 6111))
+	roundPropagateInf := bson.DecimalToDec128("99999999999999999999999999999999999" + makeManyString("0", 6144))
+
+	c.Assert(truncate, Equals, bson.Uint64x2{0x0000000000000001, 0x0000000000000000})
+	c.Assert(up, Equals, bson.Uint64x2{0x0000000000000002, 0x0000000000000000})
+	c.Assert(checkTieUp, Equals, bson.Uint64x2{0x0000000000000003, 0x0000000000000000})
+	c.Assert(checkTieTrunc, Equals, bson.Uint64x2{0x0000000000000002, 0x0000000000000000})
+
+	c.Assert(extraDigitUp, Equals, bson.Uint64x2{0x38c15b0a00000001, 0x3042314dc6448d93})
+	c.Assert(extraDigitDown, Equals, bson.Uint64x2{0x38c15b0a00000000, 0x3042314dc6448d93})
+	c.Assert(extraDigitTie, Equals, bson.Uint64x2{0x38c15b0a00000000, 0x3042314dc6448d93})
+	c.Assert(extraDigitTieBreak, Equals, bson.Uint64x2{0x38c15b0a00000001, 0x3044314dc6448d93})
+
+	c.Assert(tooBig, Equals, bson.Uint64x2{0x0000000000000000, 0x7800000000000000})
+	c.Assert(largestBinary, Equals, bson.Uint64x2{0x0000000000000000, 0x3042400000000000})
+	c.Assert(roundPropagate, Equals, bson.Uint64x2{0x38c15b0a00000000, 0x3044314dc6448d93})
+	c.Assert(roundPropagateLarge, Equals, bson.Uint64x2{0x38c15b0a00000000, 0x3084314dc6448d93})
+	c.Assert(notInf, Equals, bson.Uint64x2{0x378d8e63ffffffff, 0x5fffed09bead87c0})
+	c.Assert(roundPropagateInf, Equals, bson.Uint64x2{0x0000000000000000, 0x7800000000000000})
 }

--- a/bson/decode.go
+++ b/bson/decode.go
@@ -35,6 +35,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"gopkg.in/mgo.v2-unstable/decimal"
 )
 
 type decoder struct {
@@ -537,6 +539,8 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 		in = MongoTimestamp(d.readInt64())
 	case 0x12: // Int64
 		in = d.readInt64()
+	case 0x13: // Decimal
+		in = d.readDecimal()
 	case 0x7F: // Max key
 		in = MaxKey
 	case 0xFF: // Min key
@@ -814,6 +818,29 @@ func (d *decoder) readInt64() int64 {
 		(uint64(b[7]) << 56))
 }
 
+func (d *decoder) readDecimal() decimal.Decimal {
+	b := d.readBytes(16)
+	low64 := uint64((uint64(b[0]) << 0) |
+		(uint64(b[1]) << 8) |
+		(uint64(b[2]) << 16) |
+		(uint64(b[3]) << 24) |
+		(uint64(b[4]) << 32) |
+		(uint64(b[5]) << 40) |
+		(uint64(b[6]) << 48) |
+		(uint64(b[7]) << 56))
+	high64 := uint64((uint64(b[8]) << 0) |
+		(uint64(b[9]) << 8) |
+		(uint64(b[10]) << 16) |
+		(uint64(b[11]) << 24) |
+		(uint64(b[12]) << 32) |
+		(uint64(b[13]) << 40) |
+		(uint64(b[14]) << 48) |
+		(uint64(b[15]) << 56))
+	str := Dec128ToDecimal(Uint64x2{low64, high64})
+	dcml, _ := decimal.Parse(str)
+	return dcml
+}
+
 func (d *decoder) readByte() byte {
 	i := d.i
 	d.i++
@@ -833,4 +860,199 @@ func (d *decoder) readBytes(length int32) []byte {
 		corrupted()
 	}
 	return d.in[start : start+int(length)]
+}
+
+// --------------------------------------------------------------------------
+// Parser helpers.
+
+// uint32x4 is a struct that represents a 128 bit uint and is used
+// internally for Dec128ToDecimal parsing
+type uint32x4 struct {
+	// Stored as four 32 bit words high to low
+	parts [4]uint32
+}
+
+// divide1B divides a uint32x4 by 1000000000 (1 billion) and
+// computes the quotient and remainder
+func (value uint32x4) divide1B() (uint32x4, uint32) {
+	var quotient uint32x4
+	var remainder uint64
+	var divisor uint32 = 1000 * 1000 * 1000
+
+	if value.parts[0] == 0 && value.parts[1] == 0 &&
+	   value.parts[2] == 0 && value.parts[3] == 0 {
+		quotient = value
+		return quotient, uint32(remainder)
+	}
+
+	for i := 0; i <= 3; i++ {
+		// Adjust remainder to match value of next dividend
+		remainder <<= 32
+		// Add the dividend to remainder
+		remainder += uint64(value.parts[i])
+		quotient.parts[i] = uint32(remainder / uint64(divisor))
+		remainder %= uint64(divisor)
+	}
+
+	return quotient, uint32(remainder)
+}
+
+// Dec128ToDecimal converts two 64 bit uints to a decimal string
+func Dec128ToDecimal(dec128 Uint64x2) string {
+	var combinationMask uint32 = 0x1f    // Extract least significant 5 bits
+	var exponentMask uint32 = 0x3fff     // Extract least significant 14 bits
+	var combinationInfinity uint32 = 30  // Value of combination field for Inf
+	var combinationNaN uint32 = 31		 // Value of combination field for NaN
+	var exponentBias uint32 = 6176       // decimal128 exponent bias
+
+	var outStr string
+
+	var low = uint32(dec128.Low)		     // Bits 0 - 31
+	var midl = uint32(dec128.Low >> 32)   // Bits 32 - 63
+	var midh = uint32(dec128.High)        // Bits 64 - 95
+	var high = uint32(dec128.High >> 32)  // Bits 96 - 107
+	var combination uint32               // Bits 1 - 5
+	var biasedExponent uint32            // Decoded 14 bit biased exponent
+	var significandDigits uint32         // Number of significand digits
+	var significand [36]uint32           // Base 10 digits in significand
+	var exponent int32	                 // Unbiased exponent
+	var isZero bool 	                 // True if the number is zero
+	var significandMSB uint              // Most significant bits (50 - 46)
+
+	// dec is negative
+	if int64(dec128.High) < 0 {
+		outStr += "-"
+	}
+
+	// Decode combination field and exponent
+	combination = (high >> 26) & combinationMask
+
+	if (combination >> 3) == 3 {
+		// Check for special values
+		if combination == combinationInfinity {
+			outStr += "Inf"
+			return outStr
+		} else if combination == combinationNaN {
+			// Drop the sign, +NaN and -NaN behave the same in MongoDB
+			outStr = "NaN"
+			return outStr
+		} else {
+			biasedExponent = (high >> 15) & exponentMask
+			significandMSB = uint(0x8 + (high >> 14) & 0x01)
+		}
+	} else {
+		biasedExponent = (high >> 17) & exponentMask
+		significandMSB = uint(high >> 14) & 0x7
+	}
+
+	exponent = int32(biasedExponent - exponentBias)
+
+	// Convert 114 bit binary number in the significand to at most
+	// 34 decimal digits using modulo and division.
+	var significand128 = uint32x4{[4]uint32{
+		(high & exponentMask) + (uint32(significandMSB & 0xf) << 14),
+		midh,
+		midl,
+		low,
+	}}
+
+	if significand128.parts[0] == 0 && significand128.parts[1] == 0 &&
+	   significand128.parts[2] == 0 && significand128.parts[3] == 0 {
+	   	isZero = true
+	} else {
+		var leastDigits uint32
+		for k := 3; k >= 0; k-- {
+			significand128, leastDigits = significand128.divide1B()
+
+			// We now have the 9 least significand digits (in base 2).
+			// Convert and output to a string
+			if leastDigits == 0 {
+				continue
+			}
+
+			for j := 8; j >= 0; j-- {
+				significand[k * 9 + j] = leastDigits % 10
+				leastDigits /= 10
+			}
+		}
+	}
+
+	var significandRead uint32
+	if isZero {
+		significandDigits = 1
+		significandRead = 0
+	} else {
+		significandDigits = 36
+		// Move significandRead to where the significand is not led with zeros
+		for significandRead < 35 && significand[significandRead] == 0 {
+			significandDigits--
+			significandRead++
+		}
+	}
+
+	var scientificExponent = int32(significandDigits) - 1 + exponent
+
+	// It is much cheaper to represent our string as scientific notation if expessing
+	// it in regular format if the exponent is very large
+	if scientificExponent > 34 || scientificExponent <= -6 ||
+	   exponent > 0 || (isZero && scientificExponent != 0) {
+		// Scientific format
+		outStr += string(significand[significandRead] + '0')
+		significandRead++
+		significandDigits--
+
+		if significandDigits != 0 {
+			outStr += "."
+		}
+
+		for i := uint32(0); i < significandDigits; i++ {
+			outStr += string(significand[significandRead] + '0')
+			significandRead++
+		}
+		// Exponent
+		outStr += "E"
+		if scientificExponent > 0 {
+			outStr += "+"
+		}
+		outStr += strconv.Itoa(int(scientificExponent))
+	} else {
+		// Regular format
+		if exponent >= 0 {
+			for i := uint32(0); i < significandDigits; i++ {
+				outStr += string(significand[significandRead] + '0')
+				significandRead++
+			}
+		} else {
+			var radixPosition = int32(significandDigits) + exponent
+			if radixPosition > 0 {
+				// If we have non-zero digits before the radix
+				for i := int32(0); i< radixPosition; i++ {
+					outStr += string(significand[significandRead] + '0')
+					significandRead++
+				}
+			} else {
+				// Add a leading zero before radix point
+				outStr += "0"
+			}
+
+			outStr += "."
+			for radixPosition < 0 {
+				// Add leading zeros after radix point
+				outStr += "0"
+				radixPosition++
+			}
+			var maxRadixPosition uint32
+			if radixPosition - 1 > 0 {
+				maxRadixPosition = uint32(radixPosition - 1)
+			}
+			for i := uint32(0); i < significandDigits - maxRadixPosition; i++ {
+				outStr += string(significand[significandRead] + '0')
+				if significandRead >= uint32(len(significand) - 1) {
+					break
+				}
+				significandRead++
+			}
+		}
+	}
+	return outStr
 }

--- a/decimal/decimal.go
+++ b/decimal/decimal.go
@@ -1,0 +1,78 @@
+// Package decimal implements support for a decimal data type
+package decimal
+
+import (
+	"errors"
+	"math/big"
+	"unicode"
+)
+
+// A Decimal type for the mgo driver
+type Decimal struct {
+	finite bool
+	// Post decimal point precision
+	precision int
+	rational big.Rat
+}
+
+// String takes an integer that signifies the precision (post decimal point) at which
+// to print a decimal and it returns that string representation
+func (d Decimal) String(prec int) string {
+	if !d.finite {
+		if d.rational.Sign() == 1 {
+			return "Infinity"
+		} else if d.rational.Sign() == -1 {
+			return "-Infinity"	
+		} else {
+			return "NaN"
+		}
+	}
+	return d.rational.FloatString(prec)
+}
+
+// Parse takes a string and constructs a Decimal from the string
+func Parse(s string) (Decimal, error) {
+	precision := calculatePrecision(s)
+	rat := new(big.Rat)
+	_, success := rat.SetString(s)
+	if success {
+		return Decimal{true, precision, *rat}, nil
+	} else if s == "Inf" || s == "Infinity" {
+		// Return a decimal of 1 but note not finite
+		return Decimal{false, 0, *big.NewRat(1, 1)}, nil
+	} else if s == "-Inf" || s == "-Infinity" {
+		// Return a decimal of -1 but note not finite
+		return Decimal{false, 0, *big.NewRat(-1, 1)}, nil
+	}
+	// Return Decimal of 0 but note note finite and error
+	return Decimal{false, 0, *big.NewRat(0, 1)}, errors.New("Cannot create Decimal '" + s + "'")
+}
+
+// calculatePrecision takes a decimal string and returns its precision (post decimal point)
+func calculatePrecision(s string) int {
+	var prec = 0
+	var sawRadix = false
+	var sawExponent = false
+	for _, c := range s {
+		if c == '.' {
+			sawRadix = true
+		} else if c == 'e' || c == 'E' {
+			sawExponent = true
+		}
+		if sawRadix && !sawExponent && unicode.IsDigit(rune(c)) {
+			prec++
+		}
+	}
+	if prec == 0 && sawExponent {
+		// TODO: Investigate whether to log a note here because creating a decimal
+		// such as 2E-50 from string will maintain 34 digits of precision (post decimal)
+		// and actually be equal to 0
+		prec = 34
+	}
+	return prec
+}
+
+// GetPrecision returns the stored precision of a Decimal
+func (d Decimal) GetPrecision() int {
+	return d.precision
+}

--- a/decimal/decimal_test.go
+++ b/decimal/decimal_test.go
@@ -1,0 +1,42 @@
+package decimal_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2-unstable/decimal"
+)
+
+func TestAll(t *testing.T) {
+	TestingT(t)
+}
+
+type S struct{}
+
+var _ = Suite(&S{})
+
+func (s *S) TestDecimalStringRoundTrip(c *C) {
+	ten, err := decimal.Parse("10")
+	c.Assert(err, IsNil)
+	c.Assert(ten.String(2), Equals, "10.00")
+
+	tenth, err := decimal.Parse("0.1")
+	c.Assert(err, IsNil)
+	c.Assert(tenth.String(2), Equals, "0.10")
+
+	exponent, err := decimal.Parse("1e-5")
+	c.Assert(err, IsNil)
+	c.Assert(exponent.String(5), Equals, "0.00001")
+
+	infinity, err := decimal.Parse("Inf")
+	c.Assert(err, IsNil)
+	c.Assert(infinity.String(1), Equals, "Infinity")
+
+	ninfinity, err := decimal.Parse("-Inf")
+	c.Assert(err, IsNil)
+	c.Assert(ninfinity.String(1), Equals, "-Infinity")
+
+	failure, err := decimal.Parse("I am not a number!")
+	c.Assert(err, ErrorMatches, "Cannot create Decimal 'I am not a number!'")
+	c.Assert(failure.String(1), Equals, "NaN")
+}


### PR DESCRIPTION
I believe/hope these changes now should reflect our discussion.

I had to add two fields to the Decimal struct though:
type Decimal struct {
    finite bool
    precision int
    rational big.Rat
}

The finite boolean is used to determine whether the Decimal is infinite or finite. big.Rat doesn't have a notion of infinite numbers even though MongoDB's Decimal128 (IEEE 754) does. An infinite Decimal stores -1 in big.Rat for negative infinity and +1 in big.Rat for positive infinity along with the boolean flipped.

The precision int is used to store the post-decimal point precision of the value. The reason this is necessary is when encoding a Decimal as BSON, we must invoke the big.Rat.FloatString(prec int) method, which needs a precision (big.Rat defines precision as digits post-decimal point). When a decimal is sent from the server as BSON, we calculate its post-decimal place precision and store that in Decimal.precision. When encoding that decimal back to BSON, we use that precision for Rat.FloatString, which makes round tripping function properly.

When parsing out a precision from a decimal string, if the string is something like "2E-25" where the exponent signals the precision, we assume a max precision of 34. This is somewhat consistent with the notion that big.Rat's method of converting to a string, which never outputs scientific notation because a Rational has no notion of precision. Constructing a big.Rat with "2E-50" has more than 34 digits of "precision" (even though it technically is just 1 digit of precision) and round tripping these values, unfortunately, doesn't work perfectly (outside the range of valid MongoDB 34 digit precision decimals).

More precisely said: In mgo, when working with decimals (as they are big.Rats), there is no notion of cohorts and all values written with scientific notation are extend to regular floating point notation with added precision (since they are actually rational numbers, not decimals). Fixed point functionality can instead be achieved with using precision arguments such as in big.Rat.FloatString().
