### PR TITLE
Add primitive decimal support to mgo

### DIFF
--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -40,6 +40,7 @@ import (
 
 	. "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2-unstable/bson"
+	"gopkg.in/mgo.v2-unstable/decimal"
 	"gopkg.in/yaml.v2"
 )
 
@@ -123,6 +124,8 @@ func (s *S) TestUnmarshalSampleItems(c *C) {
 // length and last \x00 from the document. wrapInDoc() computes them.
 // Note that all of them should be supported as two-way conversions.
 
+var dcml, _ = decimal.Parse("0.1")
+
 var allItems = []testItemType{
 	{bson.M{},
 		""},
@@ -169,6 +172,8 @@ var allItems = []testItemType{
 		"\x12_\x00\x02\x01\x00\x00\x00\x00\x00\x00"},
 	{bson.M{"_": int64(258 << 32)},
 		"\x12_\x00\x00\x00\x00\x00\x02\x01\x00\x00"},
+	{bson.M{"_": dcml},
+		"\x13_\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x3e\x30"},
 	{bson.M{"_": bson.MaxKey},
 		"\x7F_\x00"},
 	{bson.M{"_": bson.MinKey},
@@ -1687,4 +1692,213 @@ func (s *S) BenchmarkUnmarshalRaw(c *C) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+// --------------------------------------------------------------------------
+// Tests for parsing and marshaling decimals.
+
+// makeManyString returns a concatenation of s, length times
+func makeManyString(s string, length int) string {
+	var ret string;
+	for i := 0; i < length; i++ {
+		ret += s
+	}
+	return ret
+}
+
+func (s *S) TestDecimalStringInfinity(c *C) {
+	positiveInfinity := bson.Dec128ToDecimal([2]uint64{0, 0x7800000000000000})
+	negativeInfinity := bson.Dec128ToDecimal([2]uint64{0, 0xf800000000000000})
+	c.Assert(positiveInfinity, Equals, "Inf")
+	c.Assert(negativeInfinity, Equals, "-Inf")
+}
+
+func (s *S) TestDecimalStringNaN(c *C) {
+	pNaN := bson.Dec128ToDecimal([2]uint64{0, 0x7c00000000000000})
+	nNaN := bson.Dec128ToDecimal([2]uint64{0, 0xfc00000000000000})
+	psNaN := bson.Dec128ToDecimal([2]uint64{0, 0x7e00000000000000})
+	nsNaN := bson.Dec128ToDecimal([2]uint64{0, 0xfe00000000000000})
+	payloadNaN := bson.Dec128ToDecimal([2]uint64{12, 0x7e00000000000000})
+	c.Assert(pNaN, Equals, "NaN")
+	c.Assert(nNaN, Equals, "NaN")
+	c.Assert(psNaN, Equals, "NaN")
+	c.Assert(nsNaN, Equals, "NaN")
+	c.Assert(payloadNaN, Equals, "NaN")
+}
+
+func (s *S) TestDecimalStringRegular(c *C) {
+	one := bson.Dec128ToDecimal([2]uint64{0x0000000000000001, 0x3040000000000000})
+	// 10E-1
+	oneShift := bson.Dec128ToDecimal([2]uint64{0x000000000000000a, 0x303e000000000000})
+	zero := bson.Dec128ToDecimal([2]uint64{0x0000000000000000, 0x3040000000000000})
+	two  := bson.Dec128ToDecimal([2]uint64{0x0000000000000002, 0x3040000000000000})
+	negativeOne := bson.Dec128ToDecimal([2]uint64{0x0000000000000001, 0xb040000000000000})
+	negativeZero := bson.Dec128ToDecimal([2]uint64{0x0000000000000000, 0xb040000000000000})
+	// 0.1
+	tenth := bson.Dec128ToDecimal([2]uint64{0x0000000000000001, 0x303e000000000000})
+	// 0.001234
+	smallestRegular := bson.Dec128ToDecimal([2]uint64{0x00000000000004d2, 0x3034000000000000})
+	// 12345789012
+	largestRegular  := bson.Dec128ToDecimal([2]uint64{0x0000001cbe991a14, 0x3040000000000000})
+	// 0.00123400000
+	trailingZeros := bson.Dec128ToDecimal([2]uint64{0x00000000075aef40, 0x302a000000000000})
+	// 0.1234567890123456789012345678901234
+	allDigits := bson.Dec128ToDecimal([2]uint64{0xde825cd07e96aff2, 0x2ffc3cde6fff9732})
+	c.Assert(one, Equals, "1")
+	c.Assert(oneShift, Equals, "1.0")
+	c.Assert(zero, Equals, "0")
+	c.Assert(two , Equals, "2")
+	c.Assert(negativeOne, Equals, "-1")
+	c.Assert(negativeZero, Equals, "-0")
+	c.Assert(tenth, Equals, "0.1")
+	c.Assert(smallestRegular, Equals, "0.001234")
+	c.Assert(largestRegular , Equals, "123456789012")
+	c.Assert(trailingZeros, Equals, "0.00123400000")
+	c.Assert(allDigits, Equals, "0.1234567890123456789012345678901234")
+}
+
+func (s *S) TestDecimalStringScientific(c *C) {
+	// 1.000000000000000000000000000000000E+6144
+	huge := bson.Dec128ToDecimal([2]uint64{0x38c15b0a00000000, 0x5ffe314dc6448d93})
+	// 1E-6176
+	tiny := bson.Dec128ToDecimal([2]uint64{0x0000000000000001, 0x0000000000000000})
+	// -1E-6176i
+	negTiny := bson.Dec128ToDecimal([2]uint64{0x0000000000000001, 0x8000000000000000})
+	// 9.999987654321E+112
+	large := bson.Dec128ToDecimal([2]uint64{0x000009184db63eb1, 0x3108000000000000})
+	// 9.999999999999999999999999999999999E+6144
+	largest := bson.Dec128ToDecimal([2]uint64{0x378d8e63ffffffff, 0x5fffed09bead87c0})
+	// 9.999999999999999999999999999999999E-6143
+	tiniest := bson.Dec128ToDecimal([2]uint64{0x378d8e63ffffffff, 0x0001ed09bead87c0})
+	// 5.192296858534827628530496329220095E+33
+	fullHouse := bson.Dec128ToDecimal([2]uint64{0xffffffffffffffff, 0x3040ffffffffffff})
+	c.Assert(huge, Equals, "1.000000000000000000000000000000000E+6144")
+	c.Assert(tiny, Equals, "1E-6176")
+	c.Assert(negTiny, Equals, "-1E-6176")
+	c.Assert(large, Equals, "9.999987654321E+112")
+	c.Assert(largest, Equals, "9.999999999999999999999999999999999E+6144")
+	c.Assert(tiniest, Equals, "9.999999999999999999999999999999999E-6143")
+	c.Assert(fullHouse, Equals, "5192296858534827628530496329220095")
+}
+
+func (s *S) TestDecimalStringZeros(c *C) {
+	// 0
+	zero := bson.Dec128ToDecimal([2]uint64{0x0000000000000000, 0x3040000000000000})
+	// 0E+300
+	posExpZero := bson.Dec128ToDecimal([2]uint64{0x0000000000000000, 0x3298000000000000})
+	// 0E-600
+	negExpZero := bson.Dec128ToDecimal([2]uint64{0x0000000000000000, 0x2b90000000000000})
+	c.Assert(zero, Equals, "0")
+	c.Assert(posExpZero, Equals, "0E+300")
+	c.Assert(negExpZero, Equals, "0E-600")
+}
+
+func (s *S) TestDecimalFromStringNaN(c *C) {
+	c.Assert(bson.DecimalToDec128("NaN"), Equals, [2]uint64{0x0000000000000000, 0x7c00000000000000})
+	c.Assert(bson.DecimalToDec128("-NaN"), Equals, [2]uint64{0x0000000000000000, 0x7c00000000000000})
+}
+
+func (s *S) TestDecimalFromStringInfinity(c *C) {
+	c.Assert(bson.DecimalToDec128("Infinity"),
+		     Equals, [2]uint64{0x0000000000000000, 0x7800000000000000})
+	c.Assert(bson.DecimalToDec128("-Infinity"),
+			 Equals, [2]uint64{0x0000000000000000, 0xf800000000000000})
+}
+
+func (s *S) TestDecimalFromStringSimple(c *C) {
+	one := bson.DecimalToDec128("1")
+	negativeOne := bson.DecimalToDec128("-1")
+	zero := bson.DecimalToDec128("0")
+	negativeZero := bson.DecimalToDec128("-0")
+	number := bson.DecimalToDec128("12345678901234567")
+	numberTwo := bson.DecimalToDec128("989898983458")
+	negativeNumber := bson.DecimalToDec128("-12345678901234567")
+	fractionalNumber := bson.DecimalToDec128("0.12345")
+	leadingZero := bson.DecimalToDec128("0.0012345")
+	leadingInsignificantZeros := bson.DecimalToDec128("00012345678901234567")
+	c.Assert(one, Equals, [2]uint64{0x0000000000000001, 0x3040000000000000})
+	c.Assert(negativeOne, Equals, [2]uint64{0x0000000000000001, 0xb040000000000000})
+	c.Assert(zero, Equals, [2]uint64{0x0000000000000000, 0x3040000000000000})
+	c.Assert(negativeZero, Equals, [2]uint64{0x0000000000000000, 0xb040000000000000})
+	c.Assert(number, Equals, [2]uint64{0x002bdc545d6b4b87, 0x3040000000000000})
+	c.Assert(numberTwo, Equals, [2]uint64{0x000000e67a93c822, 0x3040000000000000})
+	c.Assert(negativeNumber, Equals, [2]uint64{0x002bdc545d6b4b87, 0xb040000000000000})
+	c.Assert(fractionalNumber, Equals, [2]uint64{0x0000000000003039, 0x3036000000000000})
+	c.Assert(leadingZero, Equals, [2]uint64{0x0000000000003039, 0x3032000000000000})
+	c.Assert(leadingInsignificantZeros, Equals, [2]uint64{0x002bdc545d6b4b87, 0x3040000000000000})
+}
+
+func (s *S) TestDecimalFromStringLarge(c *C) {
+	large := bson.DecimalToDec128("12345689012345789012345")
+	allDigits := bson.DecimalToDec128("1234567890123456789012345678901234")
+	largest := bson.DecimalToDec128("9999999999999999999999999999999999" + makeManyString("0", 6111))
+	tiniest := bson.DecimalToDec128("0." + makeManyString("0", 6142) + "9999999999999999999999999999999999")
+	fullHouse := bson.DecimalToDec128("5192296858534827628530496329220095")
+
+	c.Assert(large, Equals, [2]uint64{0x42da3a76f9e0d979, 0x304000000000029d})
+	c.Assert(allDigits, Equals, [2]uint64{0xde825cd07e96aff2, 0x30403cde6fff9732})
+	c.Assert(largest, Equals, [2]uint64{0x378d8e63ffffffff, 0x5fffed09bead87c0})
+	c.Assert(tiniest, Equals, [2]uint64{0x378d8e63ffffffff, 0x0001ed09bead87c0})
+	c.Assert(fullHouse, Equals, [2]uint64{0xffffffffffffffff, 0x3040ffffffffffff})
+}
+
+func (s *S) TestDecimalFromStringNormalization(c *C) {
+	trailingZeros := bson.DecimalToDec128("1000000000000000000000000000000000000000")
+	oneNormalize := bson.DecimalToDec128("10000000000000000000000000000000000")
+	noNormalize := bson.DecimalToDec128("1000000000000000000000000000000000")
+	aDisaster := bson.DecimalToDec128("10000000000000000000000000000000000000000000000000000000000000000000")
+
+	zero := bson.DecimalToDec128("0." + makeManyString("0", 6176) + "1")
+
+	c.Assert(trailingZeros, Equals, [2]uint64{0x38c15b0a00000000, 0x304c314dc6448d93})
+	c.Assert(oneNormalize, Equals, [2]uint64{0x38c15b0a00000000, 0x3042314dc6448d93})
+	c.Assert(noNormalize, Equals, [2]uint64{0x38c15b0a00000000, 0x3040314dc6448d93})
+	c.Assert(aDisaster, Equals, [2]uint64{0x38c15b0a00000000, 0x3084314dc6448d93})
+	c.Assert(zero, Equals, [2]uint64{0x0000000000000000, 0x0000000000000000})
+}
+
+func (s *S) TestDecimalFromStringZeros(c *C) {
+	zero := bson.DecimalToDec128("0")
+	negativeZero := bson.DecimalToDec128("-0")
+
+	c.Assert(zero, Equals, [2]uint64{0x0000000000000000, 0x3040000000000000})
+	c.Assert(negativeZero, Equals, [2]uint64{0x0000000000000000, 0xb040000000000000})
+}
+
+func (s *S) TestDecimalFromStringRound(c *C) {
+	truncate := bson.DecimalToDec128("0." + makeManyString("0", 6175) + "10")
+	up := bson.DecimalToDec128("0." + makeManyString("0", 6175) + "15")
+	checkTieUp := bson.DecimalToDec128("0." + makeManyString("0", 6175) + "251")
+	checkTieTrunc := bson.DecimalToDec128("0." + makeManyString("0", 6175) + "250")
+
+	extraDigitUp := bson.DecimalToDec128("10000000000000000000000000000000006")
+	extraDigitDown := bson.DecimalToDec128("10000000000000000000000000000000003")
+	extraDigitTie := bson.DecimalToDec128("10000000000000000000000000000000005")
+	extraDigitTieBreak := bson.DecimalToDec128("100000000000000000000000000000000051")
+
+	tooBig := bson.DecimalToDec128("10000000000000000000000000000000006" + makeManyString("0", 6111))
+
+	largestBinary := bson.DecimalToDec128("12980742146337069071326240823050239")
+
+	roundPropagate := bson.DecimalToDec128("99999999999999999999999999999999999")
+	roundPropagateLarge := bson.DecimalToDec128("9999999999999999999999999999999999999999999999999999999999999999999")
+	notInf := bson.DecimalToDec128("9999999999999999999999999999999999" + makeManyString("0", 6111))
+	roundPropagateInf := bson.DecimalToDec128("99999999999999999999999999999999999" + makeManyString("0", 6144))
+
+	c.Assert(truncate, Equals, [2]uint64{0x0000000000000001, 0x0000000000000000})
+	c.Assert(up, Equals, [2]uint64{0x0000000000000002, 0x0000000000000000})
+	c.Assert(checkTieUp, Equals, [2]uint64{0x0000000000000003, 0x0000000000000000})
+	c.Assert(checkTieTrunc, Equals, [2]uint64{0x0000000000000002, 0x0000000000000000})
+
+	c.Assert(extraDigitUp, Equals, [2]uint64{0x38c15b0a00000001, 0x3042314dc6448d93})
+	c.Assert(extraDigitDown, Equals, [2]uint64{0x38c15b0a00000000, 0x3042314dc6448d93})
+	c.Assert(extraDigitTie, Equals, [2]uint64{0x38c15b0a00000000, 0x3042314dc6448d93})
+	c.Assert(extraDigitTieBreak, Equals, [2]uint64{0x38c15b0a00000001, 0x3044314dc6448d93})
+
+	c.Assert(tooBig, Equals, [2]uint64{0x0000000000000000, 0x7800000000000000})
+	c.Assert(largestBinary, Equals, [2]uint64{0x0000000000000000, 0x3042400000000000})
+	c.Assert(roundPropagate, Equals, [2]uint64{0x38c15b0a00000000, 0x3044314dc6448d93})
+	c.Assert(roundPropagateLarge, Equals, [2]uint64{0x38c15b0a00000000, 0x3084314dc6448d93})
+	c.Assert(notInf, Equals, [2]uint64{0x378d8e63ffffffff, 0x5fffed09bead87c0})
+	c.Assert(roundPropagateInf, Equals, [2]uint64{0x0000000000000000, 0x7800000000000000})
 }

--- a/bson/decode.go
+++ b/bson/decode.go
@@ -35,6 +35,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"gopkg.in/mgo.v2-unstable/decimal"
 )
 
 type decoder struct {
@@ -537,6 +539,8 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 		in = MongoTimestamp(d.readInt64())
 	case 0x12: // Int64
 		in = d.readInt64()
+	case 0x13: // Decimal
+		in = d.readDecimal()
 	case 0x7F: // Max key
 		in = MaxKey
 	case 0xFF: // Min key
@@ -814,6 +818,29 @@ func (d *decoder) readInt64() int64 {
 		(uint64(b[7]) << 56))
 }
 
+func (d *decoder) readDecimal() decimal.Decimal {
+	b := d.readBytes(16)
+	low64 := uint64((uint64(b[0]) << 0) |
+		(uint64(b[1]) << 8) |
+		(uint64(b[2]) << 16) |
+		(uint64(b[3]) << 24) |
+		(uint64(b[4]) << 32) |
+		(uint64(b[5]) << 40) |
+		(uint64(b[6]) << 48) |
+		(uint64(b[7]) << 56))
+	high64 := uint64((uint64(b[8]) << 0) |
+		(uint64(b[9]) << 8) |
+		(uint64(b[10]) << 16) |
+		(uint64(b[11]) << 24) |
+		(uint64(b[12]) << 32) |
+		(uint64(b[13]) << 40) |
+		(uint64(b[14]) << 48) |
+		(uint64(b[15]) << 56))
+	str := Dec128ToDecimal([2]uint64{low64, high64})
+	dcml, _ := decimal.Parse(str)
+	return dcml
+}
+
 func (d *decoder) readByte() byte {
 	i := d.i
 	d.i++
@@ -833,4 +860,192 @@ func (d *decoder) readBytes(length int32) []byte {
 		corrupted()
 	}
 	return d.in[start : start+int(length)]
+}
+
+// --------------------------------------------------------------------------
+// Parser helpers.
+
+// divide1B divides a uint128 (in 32 bit chunks) by 1000000000 (1 billion) and
+// computes the quotient and remainder
+func divide1B(value [4]uint32) ([4]uint32, uint32) {
+	var quotient [4]uint32
+	var remainder uint64
+	var divisor uint32 = 1000 * 1000 * 1000
+
+	if value[0] == 0 && value[1] == 0 &&
+	   value[2] == 0 && value[3] == 0 {
+		quotient = value
+		return quotient, uint32(remainder)
+	}
+
+	for i := 0; i <= 3; i++ {
+		// Adjust remainder to match value of next dividend
+		remainder <<= 32
+		// Add the dividend to remainder
+		remainder += uint64(value[i])
+		quotient[i] = uint32(remainder / uint64(divisor))
+		remainder %= uint64(divisor)
+	}
+
+	return quotient, uint32(remainder)
+}
+
+// Dec128ToDecimal converts two 64 bit uints to a decimal string
+func Dec128ToDecimal(dec128 [2]uint64) string {
+	var combinationMask uint32 = 0x1f    // Extract least significant 5 bits
+	var exponentMask uint32 = 0x3fff     // Extract least significant 14 bits
+	var combinationInfinity uint32 = 30  // Value of combination field for Inf
+	var combinationNaN uint32 = 31		 // Value of combination field for NaN
+	var exponentBias uint32 = 6176       // decimal128 exponent bias
+
+	var outStr string
+
+	var low = uint32(dec128[0])		     // Bits 0 - 31
+	var midl = uint32(dec128[0] >> 32)   // Bits 32 - 63
+	var midh = uint32(dec128[1])        // Bits 64 - 95
+	var high = uint32(dec128[1] >> 32)  // Bits 96 - 107
+	var combination uint32               // Bits 1 - 5
+	var biasedExponent uint32            // Decoded 14 bit biased exponent
+	var significandDigits uint32         // Number of significand digits
+	var significand [36]uint32           // Base 10 digits in significand
+	var exponent int32	                 // Unbiased exponent
+	var isZero bool 	                 // True if the number is zero
+	var significandMSB uint              // Most significant bits (50 - 46)
+
+	// dec is negative
+	if int64(dec128[1]) < 0 {
+		outStr += "-"
+	}
+
+	// Decode combination field and exponent
+	combination = (high >> 26) & combinationMask
+
+	if (combination >> 3) == 3 {
+		// Check for special values
+		if combination == combinationInfinity {
+			outStr += "Inf"
+			return outStr
+		} else if combination == combinationNaN {
+			// Drop the sign, +NaN and -NaN behave the same in MongoDB
+			outStr = "NaN"
+			return outStr
+		} else {
+			biasedExponent = (high >> 15) & exponentMask
+			significandMSB = uint(0x8 + (high >> 14) & 0x01)
+		}
+	} else {
+		biasedExponent = (high >> 17) & exponentMask
+		significandMSB = uint(high >> 14) & 0x7
+	}
+
+	exponent = int32(biasedExponent - exponentBias)
+
+	// Convert 114 bit binary number in the significand to at most
+	// 34 decimal digits using modulo and division.
+	var significand128 = [4]uint32{
+		(high & exponentMask) + (uint32(significandMSB & 0xf) << 14),
+		midh,
+		midl,
+		low,
+	}
+
+	if significand128[0] == 0 && significand128[1] == 0 &&
+	   significand128[2] == 0 && significand128[3] == 0 {
+	   	isZero = true
+	} else {
+		var leastDigits uint32
+		for k := 3; k >= 0; k-- {
+			significand128, leastDigits = divide1B(significand128)
+
+			// We now have the 9 least significand digits (in base 2).
+			// Convert and output to a string
+			if leastDigits == 0 {
+				continue
+			}
+
+			for j := 8; j >= 0; j-- {
+				significand[k * 9 + j] = leastDigits % 10
+				leastDigits /= 10
+			}
+		}
+	}
+
+	var significandRead uint32
+	if isZero {
+		significandDigits = 1
+		significandRead = 0
+	} else {
+		significandDigits = 36
+		// Move significandRead to where the significand is not led with zeros
+		for significandRead < 35 && significand[significandRead] == 0 {
+			significandDigits--
+			significandRead++
+		}
+	}
+
+	var scientificExponent = int32(significandDigits) - 1 + exponent
+
+	// It is much cheaper to represent our string as scientific notation if expessing
+	// it in regular format if the exponent is very large
+	if scientificExponent > 34 || scientificExponent <= -6 ||
+	   exponent > 0 || (isZero && scientificExponent != 0) {
+		// Scientific format
+		outStr += string(significand[significandRead] + '0')
+		significandRead++
+		significandDigits--
+
+		if significandDigits != 0 {
+			outStr += "."
+		}
+
+		for i := uint32(0); i < significandDigits; i++ {
+			outStr += string(significand[significandRead] + '0')
+			significandRead++
+		}
+		// Exponent
+		outStr += "E"
+		if scientificExponent > 0 {
+			outStr += "+"
+		}
+		outStr += strconv.Itoa(int(scientificExponent))
+	} else {
+		// Regular format
+		if exponent >= 0 {
+			for i := uint32(0); i < significandDigits; i++ {
+				outStr += string(significand[significandRead] + '0')
+				significandRead++
+			}
+		} else {
+			var radixPosition = int32(significandDigits) + exponent
+			if radixPosition > 0 {
+				// If we have non-zero digits before the radix
+				for i := int32(0); i< radixPosition; i++ {
+					outStr += string(significand[significandRead] + '0')
+					significandRead++
+				}
+			} else {
+				// Add a leading zero before radix point
+				outStr += "0"
+			}
+
+			outStr += "."
+			for radixPosition < 0 {
+				// Add leading zeros after radix point
+				outStr += "0"
+				radixPosition++
+			}
+			var maxRadixPosition uint32
+			if radixPosition - 1 > 0 {
+				maxRadixPosition = uint32(radixPosition - 1)
+			}
+			for i := uint32(0); i < significandDigits - maxRadixPosition; i++ {
+				outStr += string(significand[significandRead] + '0')
+				if significandRead >= uint32(len(significand) - 1) {
+					break
+				}
+				significandRead++
+			}
+		}
+	}
+	return outStr
 }

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -35,6 +35,9 @@ import (
 	"reflect"
 	"strconv"
 	"time"
+	"unicode"
+
+	"gopkg.in/mgo.v2-unstable/decimal"
 )
 
 // --------------------------------------------------------------------------
@@ -54,6 +57,7 @@ var (
 	typeTime           = reflect.TypeOf(time.Time{})
 	typeString         = reflect.TypeOf("")
 	typeJSONNumber     = reflect.TypeOf(json.Number(""))
+	typeDecimal        = reflect.TypeOf(decimal.Decimal{})
 )
 
 const itoaCacheSize = 32
@@ -437,6 +441,10 @@ func (e *encoder) addElem(name string, v reflect.Value, minSize bool) {
 			e.addElemName('\x02', name)
 			e.addStr(s.String())
 
+		case decimal.Decimal:
+			e.addElemName('\x13', name)
+			e.addDecimal(s)
+
 		case undefined:
 			e.addElemName('\x06', name)
 
@@ -504,6 +512,334 @@ func (e *encoder) addFloat64(v float64) {
 	e.addInt64(int64(math.Float64bits(v)))
 }
 
+func (e *encoder) addDecimal(v decimal.Decimal) {
+	dec128 := DecimalToDec128(v.String())
+	e.addBytes(
+		byte(dec128[0]),
+		byte(dec128[0]>>8),
+		byte(dec128[0]>>16),
+		byte(dec128[0]>>24),
+		byte(dec128[0]>>32),
+		byte(dec128[0]>>40),
+		byte(dec128[0]>>48),
+		byte(dec128[0]>>56),
+		byte(dec128[1]),
+		byte(dec128[1]>>8),
+		byte(dec128[1]>>16),
+		byte(dec128[1]>>24),
+		byte(dec128[1]>>32),
+		byte(dec128[1]>>40),
+		byte(dec128[1]>>48),
+		byte(dec128[1]>>56))
+}
+
 func (e *encoder) addBytes(v ...byte) {
 	e.out = append(e.out, v...)
+}
+
+// --------------------------------------------------------------------------
+// Marshaling helpers.
+
+// multiply64x64 multiplies two uint64's to get a uint128 expressed in 64 bit chunks
+func multiply64x64(left uint64, right uint64) [2]uint64 {
+	if left == 0 && right == 0 {
+		return [2]uint64{0, 0}
+	}
+	var leftHigh = left >> 32
+	var leftLow = uint64(uint32(left))
+	var rightHigh = right >> 32
+	var rightLow = uint64(uint32(right))
+
+	var productHigh = leftHigh * rightHigh
+	var productMidl = leftHigh * rightLow
+	var productMidr = leftLow * rightHigh
+	var productLow = leftLow * rightLow
+
+	productHigh += (productMidl >> 32)
+	productMidl = uint64(uint32(productMidl)) + productMidr + (productLow >> 32)
+
+	productHigh += (productMidl >> 32)
+	productLow = (productMidl << 32) + uint64(uint32(productLow))
+
+	return [2]uint64{productLow, productHigh}
+}
+
+// makeDec128Infinity returns a Dec128 +/-Infinity depending on the parameter
+func makeDec128Infinity(negative bool) [2]uint64 {
+	if !negative {
+		return [2]uint64{0, 0x7800000000000000}
+	}
+	return [2]uint64{0, 0xf800000000000000}
+}
+
+// makeDec128NaN returns a Dec128 NaN
+func makeDec128NaN() [2]uint64 {
+	return [2]uint64{0, 0x7c00000000000000}
+}
+
+// DecimalToDec128 converts a decimal string to two uint64s
+func DecimalToDec128(str string) [2]uint64 {
+	// State tracking
+	var isNegative = false
+	var sawRadix = false
+	var foundNonZero = false
+
+	var nDigitsNoTrailing uint16 // Total number of sig. digits (no trailing zeros)
+	var nDigitsRead uint16	  	 // Total number of significand digits read
+	var nDigits uint16		  	 // Total number of sig. digits
+	var radixPosition uint16  	 // The number of digits after the radix point
+	var firstNonZero uint16	  	 // The index of the first non zero
+
+	const BSONDecimalMaxDigits int = 34
+	const BSONDecimalExponentMax int = 6111
+	const BSONDecimalExponentBias int = 6176
+	const BSONDecimalExponentMin int = -6176
+	var digits [BSONDecimalMaxDigits]uint16
+	var digitsInsertPosition int
+	var nDigitsStored uint16
+	var firstDigit uint16		 // The index of the first digit
+	var lastDigit uint16		 // The index of the last digit
+
+	var exponent int32
+
+	var strRead = 0
+	var strLen = len(str)
+
+	// Check sign
+	if str[strRead] == '-' {
+		isNegative = true
+		strRead++
+	}
+
+	// Check for Infinity
+	if str[strRead:] == "Infinity" {
+		return makeDec128Infinity(isNegative)
+	}
+
+	// Check for NaN
+	if str[strRead:] == "NaN" {
+		return makeDec128NaN()
+	}
+
+	// Read digits
+	for (unicode.IsDigit(rune(str[strRead])) || str[strRead] == '.') {
+		if str[strRead] == '.' {
+			sawRadix = true
+			if strRead < strLen - 1 {
+				strRead++
+			} else {
+				break
+			}
+			continue
+		}
+
+		if nDigitsStored < 34 {
+			if str[strRead] != '0' || foundNonZero {
+				if !foundNonZero {
+					firstNonZero = nDigitsRead
+				}
+				foundNonZero = true
+				digits[digitsInsertPosition] = uint16(str[strRead]) - '0'
+				digitsInsertPosition++
+				nDigitsStored++
+			}
+		}
+
+		if foundNonZero {
+			nDigits++
+		}
+
+		if sawRadix {
+			radixPosition++
+		}
+
+		nDigitsRead++
+		if strRead < strLen - 1 {
+			strRead++
+		} else {
+			break
+		}
+	}
+
+	// Done reading input
+	// Find first non-zero digit in digits
+	if nDigitsStored == 0 {
+		firstDigit = 0
+		lastDigit = 0
+		digits[0] = 0
+		nDigits = 1
+		nDigitsStored = 1
+		nDigitsNoTrailing = 0
+	} else {
+		lastDigit = nDigitsStored - 1
+		nDigitsNoTrailing = nDigits
+		for str[firstNonZero + nDigitsNoTrailing - 1] == '0' {
+			nDigitsNoTrailing--;
+		}
+	}
+
+	// Normalization of exponent
+	// Correct exponent based on radix position and shift significand as needed
+	// to represent user input.
+
+	// Overflow prevention
+	if exponent <= int32(radixPosition) && int32(radixPosition) - exponent > (1 << 14) {
+		exponent = int32(BSONDecimalExponentMin)
+	} else {
+		exponent -= int32(radixPosition)
+	}
+
+	// Attempt to normalize the exponent
+	for exponent > int32(BSONDecimalExponentMax) {
+		// Shift the exponent to significand and decrease
+		lastDigit++
+
+		if lastDigit - firstDigit > uint16(BSONDecimalMaxDigits) {
+			return makeDec128Infinity(isNegative)
+		}
+
+		exponent--
+	}
+
+	for exponent < int32(BSONDecimalExponentMin) || nDigitsStored < nDigits {
+		// Shift the last digit
+		if lastDigit == 0 {
+			exponent = int32(BSONDecimalExponentMin)
+			// Signal zero value
+			nDigitsNoTrailing = 0
+			break;
+		}
+
+		if nDigitsStored < nDigits {
+			// Adjust to match digits not stored
+			nDigits--
+		} else {
+			// Adjust to round
+			lastDigit--
+		}
+
+		if exponent < int32(BSONDecimalExponentMax) {
+			exponent++
+		} else {
+			return makeDec128Infinity(isNegative)
+		}
+	}
+
+	// Round
+	if lastDigit - firstDigit + 1 < nDigitsNoTrailing {
+		var endOfString = nDigitsRead
+		// If we have seen a radix point, str is 1 longer than we have documented
+		// so inc the position of the first nonzero and the position digits are read to
+		if (sawRadix && exponent <= int32(BSONDecimalExponentMin)) {
+			firstNonZero++
+			endOfString++
+		}
+		// There are non-zero digits after lastDigit that need rounding
+		// Use round to nearest, ties to even rounding mode
+		var roundDigit = str[firstNonZero + lastDigit + 1] - '0'
+		var roundBit = false
+		if roundDigit >= 5 {
+			roundBit = true
+
+			if roundDigit == 5 {
+				roundBit = (digits[lastDigit] % 2 == 1)
+
+				for i := firstNonZero + lastDigit + 2; i < endOfString; i++ {
+					if (str[i] - '0') != 0 {
+						roundBit = true
+						break
+					}
+				}
+			}
+		}
+
+		if roundBit {
+			var dIdx = lastDigit
+			for ; dIdx >= 0; dIdx-- {
+				digits[dIdx]++
+				if digits[dIdx] > 9 {
+					digits[dIdx] = 0
+					// Overflowed most significant digit
+					if dIdx == 0 {
+						if exponent < int32(BSONDecimalExponentMax) {
+							exponent++
+							digits[dIdx] = 1
+							break
+						} else {
+							return makeDec128Infinity(isNegative)
+						}
+					}
+				} else {
+					break
+				}
+			}
+		}
+	}
+
+	// Encode significand
+	var significandHigh uint64
+	var significandLow uint64
+
+	if nDigitsNoTrailing == 0 {
+		// If we read a zero, significand is zero
+		significandHigh = 0
+		significandLow = 0
+	} else if lastDigit - firstDigit < 17 {
+		// If we can fit the significand entirely into the low 64 bits
+		var dIdx = firstDigit
+		significandLow = uint64(digits[dIdx])
+		dIdx++
+
+		for ; dIdx <= lastDigit; dIdx++ {
+			significandLow *= 10
+			significandLow += uint64(digits[dIdx])
+			significandHigh = 0
+		}
+	} else {
+		// We need to use both the low 64 and high 64 bits
+		var dIdx = firstDigit
+		significandHigh = uint64(digits[dIdx])
+		dIdx++
+
+		for ; dIdx <= lastDigit - 17; dIdx++ {
+			significandHigh *= 10
+			significandHigh += uint64(digits[dIdx])
+		}
+
+		significandLow = uint64(digits[dIdx])
+		dIdx++
+		for ; dIdx <= lastDigit; dIdx++ {
+			significandLow *= 10
+			significandLow += uint64(digits[dIdx])
+		}
+	}
+
+	significand := multiply64x64(significandHigh, 100000000000000000)
+	significand[0] += significandLow
+	if significand[0] < significandLow {
+		significand[1]++
+	}
+
+	// Encode combination and exponent with significand
+	var biasedExponent = uint16(exponent + int32(BSONDecimalExponentBias))
+	var decHigh64 uint64
+	var decLow64 uint64
+
+	if (significand[1] >> 49) & 1 != 0 {
+		decHigh64 |= (0x3 << 61)
+		decHigh64 |= uint64((biasedExponent & 0x3fff)) << 47
+		decHigh64 |= (significand[1] & 0x7fffffffffff)
+	} else {
+		decHigh64 |= uint64((biasedExponent & 0x3fff)) << 49
+		decHigh64 |= (significand[1] & 0x1ffffffffffff)
+	}
+
+	decLow64 = significand[0]
+
+	// Encode sign
+	if isNegative {
+		decHigh64 |= 0x8000000000000000
+	}
+
+	return [2]uint64{decLow64, decHigh64}
 }

--- a/decimal/decimal.go
+++ b/decimal/decimal.go
@@ -1,0 +1,58 @@
+// Package decimal implements support for a decimal data type
+package decimal
+
+import (
+	"errors"
+	"math/big"
+)
+
+// A Decimal type for the mgo driver
+type Decimal struct {
+	finite bool
+	rational big.Rat
+}
+
+// String returns a float string representation of a Decimal
+func (d Decimal) String() string {
+	// Retrieve a copy of the Decimal's internal big.Rat denominator
+	denom := new(big.Int)
+	denom.Set(d.rational.Denom())
+	// Discover the precision of the denominator and use it to fix
+	// the precision of the string conversion
+	var precision = 0
+	one := big.NewInt(1)
+	ten := big.NewInt(10)
+	for denom.Cmp(one) > 0 {
+		denom = denom.Div(denom, ten)
+		precision++
+	}
+
+	if !d.finite {
+		if d.rational.Sign() == 1 {
+			return "Infinity"
+		} else if d.rational.Sign() == -1 {
+			return "-Infinity"	
+		} else {
+			return "NaN"
+		}
+	}
+
+	return d.rational.FloatString(precision)
+}
+
+// Parse takes a string and constructs a Decimal from the string
+func Parse(s string) (Decimal, error) {
+	rat := new(big.Rat)
+	_, success := rat.SetString(s)
+	if success {
+		return Decimal{true, *rat}, nil
+	} else if s == "Inf" || s == "Infinity" {
+		// Return a decimal of 1 but note not finite
+		return Decimal{false, *big.NewRat(1, 1)}, nil
+	} else if s == "-Inf" || s == "-Infinity" {
+		// Return a decimal of -1 but note not finite
+		return Decimal{false, *big.NewRat(-1, 1)}, nil
+	}
+	// Return Decimal of 0 but note note finite and error
+	return Decimal{false, *big.NewRat(0, 1)}, errors.New("Cannot create Decimal '" + s + "'")
+}

--- a/decimal/decimal_test.go
+++ b/decimal/decimal_test.go
@@ -1,0 +1,62 @@
+package decimal_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2-unstable/decimal"
+)
+
+func TestAll(t *testing.T) {
+	TestingT(t)
+}
+
+type S struct{}
+
+var _ = Suite(&S{})
+
+func (s *S) TestDecimalStringRoundTrip(c *C) {
+	ten, err := decimal.Parse("10")
+	c.Assert(err, IsNil)
+	c.Assert(ten.String(), Equals, "10")
+
+	tenth, err := decimal.Parse("0.1")
+	c.Assert(err, IsNil)
+	c.Assert(tenth.String(), Equals, "0.1")
+
+	twoTenths, err := decimal.Parse("0.2")
+	c.Assert(err, IsNil)
+	c.Assert(twoTenths.String(), Equals, "0.2")
+
+	nineTenths, err := decimal.Parse("0.9")
+	c.Assert(err, IsNil)
+	c.Assert(nineTenths.String(), Equals, "0.9")
+
+	thousandth, err := decimal.Parse("0.001")
+	c.Assert(err, IsNil)
+	c.Assert(thousandth.String(), Equals, "0.001")
+
+	exponent, err := decimal.Parse("1e-5")
+	c.Assert(err, IsNil)
+	c.Assert(exponent.String(), Equals, "0.00001")
+
+	exponent2, err := decimal.Parse("2e-50")
+	c.Assert(err, IsNil)
+	c.Assert(exponent2.String(), Equals, "0.00000000000000000000000000000000000000000000000002")
+
+	float2, err := decimal.Parse("0.00000000000000000000000000000000000000000000000002")
+	c.Assert(err, IsNil)
+	c.Assert(float2.String(), Equals, "0.00000000000000000000000000000000000000000000000002")
+
+	infinity, err := decimal.Parse("Inf")
+	c.Assert(err, IsNil)
+	c.Assert(infinity.String(), Equals, "Infinity")
+
+	ninfinity, err := decimal.Parse("-Inf")
+	c.Assert(err, IsNil)
+	c.Assert(ninfinity.String(), Equals, "-Infinity")
+
+	failure, err := decimal.Parse("I am not a number!")
+	c.Assert(err, ErrorMatches, "Cannot create Decimal 'I am not a number!'")
+	c.Assert(failure.String(), Equals, "NaN")
+}


### PR DESCRIPTION
Fixed the decimal precision stuff & addressed your other comments.

Quick question though -- when users enter in decimal.Parse("1/3"), they'll get a precision of 1. Should we just disallow users from Parsing from a string with a "/" in it?

Thanks so much for the review comments!
