### PR TITLE
add support and test for cursor first batch and cursor get more method.

### DIFF
--- a/cursor_batch.go
+++ b/cursor_batch.go
@@ -1,0 +1,47 @@
+package mgo
+
+import "gopkg.in/mgo.v2/bson"
+
+// CursorGetMore gets a subsequent batch of documents for a given cursorID.
+// Typically the cursorID is the one created using CursorFirstBatch. The
+// numberToReturn indicates how many documents should be returned. This is the
+// same as the "Batch" configuration on the Query, but it does not use the
+// default session Batch and passes the value here to Mongo as is. The method
+// returns the batch of documents, a boolean which is true if this is the last
+// batch, and possibly an error.
+func (c *Collection) CursorGetMore(cursor int64, numberToReturn int32) (batch []bson.Raw, exhausted bool, err error) {
+	iter := c.NewIter(nil, nil, cursor, nil)
+	iter.op.limit = numberToReturn
+	batch, cursor, err = iter.getBatchDataAndCursor()
+	return batch, cursor == 0, err
+}
+
+// CursorFirstBatch creates a new cursor and returns it's ID and the first
+// batch of data. Use CursorGetMore to get subsequent batches of data.
+func (q *Query) CursorFirstBatch() (batch []bson.Raw, cursorID int64, err error) {
+	iter := q.Iter()
+	return iter.getBatchDataAndCursor()
+}
+
+func (iter *Iter) getBatchDataAndCursor() ([]bson.Raw, int64, error) {
+	var first bson.Raw
+	if iter.err == nil {
+		if !iter.Next(&first) {
+			return nil, 0, iter.Err()
+		}
+	} else {
+		return nil, 0, iter.Err()
+	}
+
+	results := make([]bson.Raw, 0, iter.docData.Len())
+	results = append(results, first)
+	for iter.docData.Len() != 0 {
+		m := iter.docData.Pop()
+		results = append(results, bson.Raw{
+			Kind: 0x03,
+			Data: m.([]byte),
+		})
+	}
+
+	return results, iter.op.cursorId, nil
+}

--- a/cursor_batch_test.go
+++ b/cursor_batch_test.go
@@ -1,0 +1,107 @@
+package mgo_test
+
+import (
+	. "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+func (s *S) TestGetMore(c *C) {
+	session, err := mgo.Dial("localhost:40001")
+	session.SetBatch(4)
+	c.Assert(err, IsNil)
+	defer session.Close()
+
+	coll := session.DB("mydb").C("mycoll")
+	for i := 0; i < 10; i++ {
+		coll.Insert(M{"n": i})
+	}
+
+	// Test random cursor should return error
+	batch, exhauted, err := coll.CursorGetMore(12345, 123)
+	c.Assert(err, ErrorMatches, "invalid cursor")
+
+	// Test First Batch should return batch and cursor, no error
+	batch, cursor, err := coll.Find(nil).CursorFirstBatch()
+	c.Assert(len(batch), Equals, 4)
+	c.Assert(cursor == 0, Equals, false)
+	c.Assert(err == nil, Equals, true)
+
+	// Test first call of GetMore should return batch and not exhausted yet, no error
+	batch, exhauted, err = coll.CursorGetMore(cursor, 4)
+	c.Assert(len(batch), Equals, 4)
+	c.Assert(exhauted, Equals, false)
+	c.Assert(err == nil, Equals, true)
+
+	// Test second call of GetMore should return batch and exhausted, no error
+	batch, exhauted, err = coll.CursorGetMore(cursor, 4)
+	c.Assert(len(batch), Equals, 2)
+	c.Assert(exhauted, Equals, true)
+	c.Assert(err == nil, Equals, true)
+}
+
+func (s *S) TestCursorFirstBatchAndGetMore(c *C) {
+	session, err := mgo.Dial("localhost:40001")
+	c.Assert(err, IsNil)
+	defer session.Close()
+
+	coll := session.DB("mydb").C("mycoll")
+	//Test the case db and coll doesn't exist
+	batch, cursor, err := coll.Find(nil).Batch(5).CursorFirstBatch()
+	c.Assert(len(batch), Equals, 0)
+	c.Assert(cursor == 0, Equals, true)
+	c.Assert(err, IsNil)
+
+	for i := 0; i < 10; i++ {
+		coll.Insert(M{"n": i})
+	}
+
+	//test the case get the first batch and still have document in coll
+	batch, cursor, err = coll.Find(nil).Batch(5).Sort("n").CursorFirstBatch()
+	iter := coll.Find(nil).Batch(5).Sort("n").Iter()
+	c.Assert(err, IsNil)
+	c.Assert(len(batch), Equals, 5)
+	for i := 0; i < 5; i++ {
+		itemRaw := batch[i]
+		var item, itemNormal bson.M
+		err := itemRaw.Unmarshal(&item)
+		c.Assert(err, IsNil)
+		ok := iter.Next(&itemNormal)
+		c.Assert(ok, Equals, true)
+		c.Assert(item, DeepEquals, itemNormal)
+	}
+	c.Assert(cursor == 0, Equals, false)
+
+	// test the cursorid can be used to recreate iter
+	batch, exhausted, err := coll.CursorGetMore(cursor, 5)
+	c.Assert(err, IsNil)
+	c.Assert(exhausted, Equals, false)
+	c.Assert(len(batch), Equals, 5)
+	for i := 0; i < 5; i++ {
+		itemRaw := batch[i]
+		var item, itemNormal bson.M
+		err := itemRaw.Unmarshal(&item)
+		c.Assert(err, IsNil)
+		ok := iter.Next(&itemNormal)
+		c.Assert(ok, Equals, true)
+		c.Assert(item, DeepEquals, itemNormal)
+	}
+	batch, exhausted, err = coll.CursorGetMore(cursor, 5)
+	c.Assert(err, IsNil)
+	c.Assert(exhausted, Equals, true)
+	c.Assert(len(batch), Equals, 0)
+
+	//test the case the first batch exhaust the collection
+	query := coll.Find(nil).Batch(10)
+	batch, cursor, err = query.CursorFirstBatch()
+	c.Assert(err, IsNil)
+	c.Assert(len(batch), Equals, 10)
+	c.Assert(cursor == 0, Equals, true)
+
+	//test the case the first batch exhaust the collection
+	query = coll.Find(nil).Batch(20)
+	batch, cursor, err = query.CursorFirstBatch()
+	c.Assert(err, IsNil)
+	c.Assert(len(batch), Equals, 10)
+	c.Assert(cursor == 0, Equals, true)
+}


### PR DESCRIPTION
Hi, we took a stab at the feature request we described in #170. It exposes 2 new methods to create a new cursor and continue iterating on the cursor. They're definitely plumbing methods and should have some clear docs saying "dont do this unless you know what you're doing". We're using this along with `connect=direct` and `Secondary` mode. We're still not in production with this but wanted to share it early to get your feedback.

For now they're in separate files but that's just so we can keep rebasing with ease. We can move the code to the appropriate files on your guidance.
