### PR TITLE
dbs.server.Process.Signal(os.Interrupt) instead of kill , kill causes…

### DIFF
--- a/dbtest/dbserver.go
+++ b/dbtest/dbserver.go
@@ -111,7 +111,7 @@ func (dbs *DBServer) Stop() {
 	}
 	if dbs.server != nil {
 		dbs.tomb.Kill(nil)
-		dbs.server.Process.Kill()
+		dbs.server.Process.Signal(os.Interrupt)
 		select {
 		case <-dbs.tomb.Dead():
 		case <-time.After(5 * time.Second):


### PR DESCRIPTION
… mongod exit unexpected

dbs.server.Process.Signal(os.Interrupt) instead of kill , kill causes mongod exit unexpected
