### PR TITLE
Bug when a Mongo field name contains a slash

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -618,24 +618,6 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 			continue
 		}
 
-		// XXX Drop this after a few releases.
-		if s := strings.Index(tag, "/"); s >= 0 {
-			recommend := tag[:s]
-			for _, c := range tag[s+1:] {
-				switch c {
-				case 'c':
-					recommend += ",omitempty"
-				case 's':
-					recommend += ",minsize"
-				default:
-					msg := fmt.Sprintf("Unsupported flag %q in tag %q of type %s", string([]byte{uint8(c)}), tag, st)
-					panic(externalPanic(msg))
-				}
-			}
-			msg := fmt.Sprintf("Replace tag %q in field %s of type %s by %q", tag, field.Name, st, recommend)
-			panic(externalPanic(msg))
-		}
-
 		inline := false
 		fields := strings.Split(tag, ",")
 		if len(fields) > 1 {


### PR DESCRIPTION
I am trying to map a field containing a slash to a struct field using a tag:

```
type user struct {
    FooBar `bson:"foo/bar"`
}
```

But when I do this I get a panic: `Unsupported flag "a" in tag "foo/bar" of type struct ...`

It is caused by a block of code which has this comment: `// XXX Drop this after a few releases.`

Maybe it is time to drop that code?
