### PR TITLE
Copy the bson.Binary data from the source buffer

### DIFF
--- a/bson/decode.go
+++ b/bson/decode.go
@@ -461,6 +461,7 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 			case typeRawDocElem:
 				out.Set(d.readRawDocElems(outt))
 			}
+			d.readDocTo(blackHole)
 			return true
 		}
 		d.readDocTo(blackHole)


### PR DESCRIPTION
If one was unmarshaling from a buffer that gets reused, bson.Binary
values would get corrupted.
