### PR TITLE
correctly skip docs incorrectly being read in to slices

### DIFF
--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -549,6 +549,10 @@ var unmarshalItems = []testItemType{
 	// Decode old binary without length. According to the spec, this shouldn't happen.
 	{bson.M{"_": []byte("old")},
 		"\x05_\x00\x03\x00\x00\x00\x02old"},
+
+	// Decode a doc within a doc in to a slice within a doc; shouldn't error
+	{&struct{ Foo []string }{},
+		"\x03\x66\x6f\x6f\x00\x05\x00\x00\x00\x00"},
 }
 
 func (s *S) TestUnmarshalOneWayItems(c *C) {

--- a/bson/decode.go
+++ b/bson/decode.go
@@ -460,6 +460,8 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 				out.Set(d.readDocElems(outt))
 			case typeRawDocElem:
 				out.Set(d.readRawDocElems(outt))
+			default:
+				d.readDocTo(blackHole)
 			}
 			return true
 		}


### PR DESCRIPTION
When trying to parse a bson document as a slice, and the slice is not of DocElem or RawDocElem, readElemTo would decide to do nothing, but didn't consume the element, leaving the decoder in a bad state.
