### PR TITLE
Apply io.Closer interface for *mgo.Session

### DIFF
--- a/session.go
+++ b/session.go
@@ -1539,7 +1539,7 @@ func (s *Session) Clone() *Session {
 
 // Close terminates the session.  It's a runtime error to use a session
 // after it has been closed.
-func (s *Session) Close() {
+func (s *Session) Close() error {
 	s.m.Lock()
 	if s.cluster_ != nil {
 		debugf("Closing session %p", s)
@@ -1548,6 +1548,7 @@ func (s *Session) Close() {
 		s.cluster_ = nil
 	}
 	s.m.Unlock()
+	return nil
 }
 
 func (s *Session) cluster() *mongoCluster {


### PR DESCRIPTION
I often use `io.Closer` . e.g.

``` go
func AddSignalListenCloser(tag string, closer io.Closer, trigger ...os.Signal) error {

    if tag == "" {
        return fmt.Errorf("singnal: tag should not be empty")
    }

    if closer == nil {
        return fmt.Errorf("singnal: closer should not be nil")
    }

    sigChan := make(chan os.Signal, 1)
    signal.Notify(sigChan, trigger...)

    go wait(sigChan, tag, closer)

    return nil
}

func wait(sigChan chan os.Signal, tag string, closer io.Closer) {

    for {
        <-sigChan
        var err error
        if closer != nil {
            err = closer.Close()
        }
        panic(fmt.Errorf("singnal: %s is close, err = %s", tag, err))
    }

}
```

I want to apply *mgo.Session.
