### PR TITLE
make decoder can secode string to int

### DIFF
--- a/bson/decode.go
+++ b/bson/decode.go
@@ -670,8 +670,8 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 		case reflect.String:
 			if parseInt, err := strconv.ParseInt(inv.String(), 10, 64); err == nil {
 				out.SetInt(parseInt)
+				return true
 			}
-			return true
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 			panic("can't happen: no uint types in BSON (!?)")
 		}

--- a/bson/decode.go
+++ b/bson/decode.go
@@ -667,6 +667,11 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 				out.SetInt(0)
 			}
 			return true
+		case reflect.String:
+			if parseInt, err := strconv.ParseInt(inv.String(), 10, 64); err == nil {
+				out.SetInt(parseInt)
+			}
+			return true
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 			panic("can't happen: no uint types in BSON (!?)")
 		}


### PR DESCRIPTION
Now, when the bson type is `string` but the go type is `int`, it will do nothing. I think it's much more convenient and helpful to parse string to int and set to the field.
