### PR TITLE
bson: Fix for ,inline-d structs of unexported embedded for Go 1.6.

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -627,7 +627,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 	inlineMap := -1
 	for i := 0; i != n; i++ {
 		field := st.Field(i)
-		if field.PkgPath != "" {
+		if field.PkgPath != "" && !field.Anonymous {
 			continue // Private field
 		}
 

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -1053,6 +1053,13 @@ type inlineDupMap struct {
 type inlineBadKeyMap struct {
 	M map[int]int ",inline"
 }
+type inlineUnexported struct {
+	M          map[string]interface{} ",inline"
+	unexported         ",inline"
+}
+type unexported struct {
+	A int
+}
 
 type getterSetterD bson.D
 
@@ -1284,6 +1291,7 @@ var twoWayCrossItems = []crossTypeItem{
 	{&inlineMapInt{A: 1, M: map[string]int{"b": 2}}, map[string]int{"a": 1, "b": 2}},
 	{&inlineMapInt{A: 1, M: nil}, map[string]int{"a": 1}},
 	{&inlineMapMyM{A: 1, M: MyM{"b": MyM{"c": 3}}}, map[string]interface{}{"a": 1, "b": map[string]interface{}{"c": 3}}},
+	{&inlineUnexported{M: map[string]interface{}{"b": 1}, unexported: unexported{A: 2}}, map[string]interface{}{"b": 1, "a": 2}},
 
 	// []byte <=> Binary
 	{&struct{ B []byte }{[]byte("abc")}, map[string]bson.Binary{"b": bson.Binary{Data: []byte("abc")}}},

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -188,7 +188,7 @@ func isZero(v reflect.Value) bool {
 			return v.Interface().(time.Time).IsZero()
 		}
 		for i := 0; i < v.NumField(); i++ {
-			if vt.Field(i).PkgPath != "" {
+			if vt.Field(i).PkgPath != "" && !vt.Field(i).Anonymous {
 				continue // Private field
 			}
 			if !isZero(v.Field(i)) {


### PR DESCRIPTION
Addresses issue #227 
