### PR TITLE
Reduce memory footprint by reusing buffers

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -489,8 +489,15 @@ func handleErr(err *error) {
 //     }
 //
 func Marshal(in interface{}) (out []byte, err error) {
+	return MarshalBuffer(in, make([]byte, 0, initialBufferSize))
+}
+
+// MarshalBuffer behaves the same way as Marshal, except that instead of
+// allocating a new byte slice it tries to use the received byte slice and
+// only allocates more memory if necessary to fit the marshaled value.
+func MarshalBuffer(in interface{}, buf []byte) (out []byte, err error) {
 	defer handleErr(&err)
-	e := &encoder{make([]byte, 0, initialBufferSize)}
+	e := &encoder{buf}
 	e.addDoc(reflect.ValueOf(in))
 	return e.out, nil
 }

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -249,6 +249,13 @@ func (s *S) TestUnmarshalNonNilInterface(c *C) {
 	c.Assert(m, DeepEquals, bson.M{"a": 1})
 }
 
+func (s *S) TestMarshalBuffer(c *C) {
+	buf := make([]byte, 0, 256)
+	data, err := bson.MarshalBuffer(bson.M{"a": 1}, buf)
+	c.Assert(err, IsNil)
+	c.Assert(data, DeepEquals, buf[:len(data)])
+}
+
 // --------------------------------------------------------------------------
 // Some one way marshaling operations which would unmarshal differently.
 


### PR DESCRIPTION
This PR adds some benchmarks for `Collection.Insert()` and changes `mongoSocket.Query()` and `addBSON()` to reuse allocated `[]byte` buffers by getting and putting then into a `sync.Pool`.

Also the function `MarshalBuffer` was added to the bson package. It behaves in the exact same way as Marshal but instead of allocating a []byte buffer it receives an already existing buffer.

I came upon these changes after profiling a real world application that inserts a lot of documents simultaneously.

The added benchmarks show a really nice decrease in memory footprint specially when large messages are being sent to MongoDB, as is the case of inserting multiple documents at once:

```
$ benchcmp before.txt after.txt
benchmark                     old ns/op     new ns/op     delta
BenchmarkInsertSingle-4       94191         90779         -3.62%
BenchmarkInsertMultiple-4     1076423       937569        -12.90%

benchmark                     old allocs     new allocs     delta
BenchmarkInsertSingle-4       50             46             -8.00%
BenchmarkInsertMultiple-4     456            242            -46.93%

benchmark                     old bytes     new bytes     delta
BenchmarkInsertSingle-4       2472          1320          -46.60%
BenchmarkInsertMultiple-4     191180        29228         -84.71%
```

I did't use gocheck for the benchmarks because it was returning some weird numbers. I'm not sure whether I did something wrong but these are the numbers for the exact same code only adapting it to use gocheck:

```
$ go test -check.f BenchmarkInsert -check.b -check.bmem
PASS: session_test.go:4191: S.BenchmarkInsertMultiple        500       2627615 ns/op      813412 B/op       2612 allocs/op
PASS: session_test.go:4175: S.BenchmarkInsertSingle     5000        265921 ns/op       16268 B/op        214 allocs/op
OK: 2 passed
PASS
ok      gopkg.in/mgo.v2 3.462s
```

Compared to the use of native benchmarks:

```
$ go test -check.f xxx -test.bench BenchmarkInsert -test.benchmem
OK: 0 passed
PASS
BenchmarkInsertSingle-4        20000         99943 ns/op        1384 B/op         48 allocs/op
BenchmarkInsertMultiple-4       2000       1101579 ns/op       32590 B/op        343 allocs/op
ok      gopkg.in/mgo.v2 5.449s
```

Maybe I did something wrong and I'm open to work on it further if you have any tips.
