### PR TITLE
Add Collection.Exists() and Collection.IsCapped()

### DIFF
--- a/session.go
+++ b/session.go
@@ -2095,6 +2095,56 @@ func (c *Collection) Repair() *Iter {
 	return clonedc.NewIter(session, result.Cursor.FirstBatch, result.Cursor.Id, err)
 }
 
+// Exists checks to see if a collection exists, if it does the passed
+// result will be populated.
+func (c *Collection) Exists(result interface{}) bool {
+	// Clone session and set it to Monotonic mode so that the server
+	// used for the query may be safely obtained afterwards, if
+	// necessary for iteration when a cursor is received.
+	session := c.Database.Session
+	cloned := session.nonEventual()
+	defer cloned.Close()
+
+	var cmdResult struct{
+		Ok float64 `bson:"ok"`
+		Cursor cursorData `bson:"cursor"`
+	}
+
+	clonedc := c.With(cloned)
+
+	err := clonedc.Database.Run(bson.D{{"listCollections", 1}, {"filter", bson.M{"name": c.Name}}}, &cmdResult)
+	if cmdResult.Ok == 1 {
+		cursor := clonedc.NewIter(session, cmdResult.Cursor.FirstBatch, cmdResult.Cursor.Id, err)
+		if cursor.Next(result) {
+			return true
+		}
+		return false
+	}
+
+	if err != nil && strings.HasPrefix(err.Error(), "no such cmd") {
+		err = clonedc.Database.C("system.namespaces").Find(bson.M{"name": fmt.Sprintf("%s.%s", clonedc.Database.Name, c.Name)}).One(result)
+		if err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsCapped checks to see if a collection is a capped collection
+func (c *Collection) IsCapped() bool {
+	var result struct{
+		Options struct {
+			Capped bool `bson: "capped"`
+		} `bson:"options"`
+	}
+
+	if c.Exists(&result) {
+		return result.Options.Capped
+	}
+	return false
+}
+
 // FindId is a convenience helper equivalent to:
 //
 //     query := collection.Find(bson.M{"_id": id})

--- a/session_test.go
+++ b/session_test.go
@@ -3755,6 +3755,55 @@ func (s *S) TestRepairCursor(c *C) {
 	}
 }
 
+func (s *S) TestExists(c *C) {
+	// version check...
+
+	session, err := mgo.Dial("localhost:40001")
+	c.Assert(err, IsNil)
+	defer session.Close()
+
+	coll := session.DB("mydb").C("mycoll4")
+	err = coll.DropCollection()
+
+	c.Assert(coll.Exists(nil), Equals, false)
+
+	err = coll.Create(&mgo.CollectionInfo{})
+	c.Assert(err, IsNil)
+
+	c.Assert(coll.Exists(nil), Equals, true)
+}
+
+func (s *S) TestIsCapped(c *C) {
+	// version check...
+
+	session, err := mgo.Dial("localhost:40001")
+	c.Assert(err, IsNil)
+	defer session.Close()
+
+	coll := session.DB("mydb").C("mycoll4")
+	err = coll.DropCollection()
+
+	c.Assert(coll.IsCapped(), Equals, false)
+
+	err = coll.Create(&mgo.CollectionInfo{})
+	c.Assert(err, IsNil)
+
+	c.Assert(coll.IsCapped(), Equals, false)
+
+	err = coll.DropCollection()
+
+	info := &mgo.CollectionInfo{
+		Capped:   true,
+		MaxBytes: 1024,
+		MaxDocs:  3,
+	}
+
+	err = coll.Create(info)
+	c.Assert(err, IsNil)
+
+	c.Assert(coll.IsCapped(), Equals, true)
+}
+
 func (s *S) TestPipeIter(c *C) {
 	if !s.versionAtLeast(2, 1) {
 		c.Skip("Pipe only works on 2.1+")


### PR DESCRIPTION
Modelled directly after the mongo cli

```
function (){
    var e = this.exists();
    return ( e && e.options && e.options.capped ) ? true : false;
}
```

```
function (){
    var res = this._db.runCommand( "listCollections",
                                  { filter : { name : this._shortName } } );
    if ( res.ok ) {
        var cursor = new DBCommandCursor( this._mongo, res );
        if ( !cursor.hasNext() )
            return null;
        return cursor.next();
    }

    if ( res.errmsg && res.errmsg.startsWith( "no such cmd" ) ) {
        return this._db.system.namespaces.findOne( { name : this._fullName } );
    }

    throw _getErrorWithCode(res, "listCollections failed: " + tojson(res));
}
```
