### PR TITLE
Fixed error iteration in writeOp

### DIFF
--- a/session.go
+++ b/session.go
@@ -4525,7 +4525,7 @@ func (c *Collection) writeOp(op interface{}, ordered bool) (lerr *LastError, err
 				lerr.N += oplerr.N
 				lerr.modified += oplerr.modified
 				if err != nil {
-					for ei := range lerr.ecases {
+					for ei := range oplerr.ecases {
 						oplerr.ecases[ei].Index += i
 					}
 					lerr.ecases = append(lerr.ecases, oplerr.ecases...)


### PR DESCRIPTION
The for-range loop incorrectly iterated over lerr.ecases when indexing into oplerr.ecases, causing out of bounds panics if there were errors in previous iterations of the outer loop (which limits the batch size).
