### PR TITLE
fix the addition index ExpireAfter, for mongo 2.6.10

### DIFF
--- a/session.go
+++ b/session.go
@@ -1235,7 +1235,7 @@ func (c *Collection) EnsureIndex(index Index) error {
 		Min:              index.Minf,
 		Max:              index.Maxf,
 		BucketSize:       index.BucketSize,
-		ExpireAfter:      int(index.ExpireAfter / time.Second),
+		ExpireAfter:      int(index.ExpireAfter),
 		Weights:          keyInfo.weights,
 		DefaultLanguage:  index.DefaultLanguage,
 		LanguageOverride: index.LanguageOverride,
@@ -2332,7 +2332,7 @@ type queryError struct {
 	ErrMsg        string
 	Assertion     string
 	Code          int
-	AssertionCode int        "assertionCode"
+	AssertionCode int "assertionCode"
 }
 
 type QueryError struct {


### PR DESCRIPTION
I could not add any ExpireAfter index(no errors), only when fix the division, it worked.
also: https://groups.google.com/forum/#!topic/mgo-users/WV7aparsI1o
