### PR TITLE
add mongo Index int64 type support

### DIFF
--- a/session.go
+++ b/session.go
@@ -1480,10 +1480,21 @@ func (idxs indexSlice) Swap(i, j int)      { idxs[i], idxs[j] = idxs[j], idxs[i]
 func simpleIndexKey(realKey bson.D) (key []string) {
 	for i := range realKey {
 		field := realKey[i].Name
-		vi, ok := realKey[i].Value.(int)
-		if !ok {
-			vf, _ := realKey[i].Value.(float64)
-			vi = int(vf)
+		value := realKey[i].Value
+
+		vi := 0
+		switch t := value.(type) {
+		case int:
+			vi = value.(t)
+		case int64:
+			vi = int(value.(t))
+		case float64:
+			vi = int(value.(t))
+		case string:
+			key = append(key, "$"+value.(t)+":"+field)
+			continue
+		default:
+			panic("Got unknown index key type for field " + field)
 		}
 		if vi == 1 {
 			key = append(key, field)
@@ -1493,11 +1504,6 @@ func simpleIndexKey(realKey bson.D) (key []string) {
 			key = append(key, "-"+field)
 			continue
 		}
-		if vs, ok := realKey[i].Value.(string); ok {
-			key = append(key, "$"+vs+":"+field)
-			continue
-		}
-		panic("Got unknown index key type for field " + field)
 	}
 	return
 }


### PR DESCRIPTION
It will panic with **"Got unknown index key type for field "**
When mongo index with **NumberLong** type.
And call collection.**Indexes()** function

I check the type in golang, it will use **int64** type which mgo **simpleIndexKey** function don't support.

Check this solution.
