### PR TITLE
PurgeMissing now removes invalid transaction tokens

### DIFF
--- a/txn/txn.go
+++ b/txn/txn.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -382,8 +383,8 @@ func (r *Runner) ChangeLog(logc *mgo.Collection) {
 func (r *Runner) PurgeMissing(collections ...string) error {
 
 	type TDoc struct {
-		Id       interface{} "_id"
-		TxnQueue []string    "txn-queue"
+		Id       interface{}   "_id"
+		TxnQueue []interface{} "txn-queue"
 	}
 
 	found := make(map[bson.ObjectId]bool)
@@ -405,10 +406,18 @@ func (r *Runner) PurgeMissing(collections ...string) error {
 		var tdoc TDoc
 		for iter.Next(&tdoc) {
 			for _, txnToken := range tdoc.TxnQueue {
-				txnId := tokenToId(txnToken)
-				if !txnExists(txnId) {
-					logf("WARNING: purging from document %s/%v the missing transaction id %s", collection, tdoc.Id, txnId)
-					if err := pullTxn(c, tdoc.Id, txnId); err != nil {
+				if txnId, ok := tokenToId(txnToken); ok {
+					if !txnExists(txnId) {
+						logf("WARNING: purging from document %s/%v the missing transaction id %s",
+							collection, tdoc.Id, txnId)
+						if err := pullTxn(c, tdoc.Id, txnId); err != nil {
+							return err
+						}
+					}
+				} else {
+					logf("WARNING: purging from document %s/%v the invalid transaction token %#v",
+						collection, tdoc.Id, txnToken)
+					if err := pullToken(c, tdoc.Id, txnToken); err != nil {
 						return err
 					}
 				}
@@ -420,18 +429,26 @@ func (r *Runner) PurgeMissing(collections ...string) error {
 	}
 
 	type StashTDoc struct {
-		Id       docKey   "_id"
-		TxnQueue []string "txn-queue"
+		Id       docKey        "_id"
+		TxnQueue []interface{} "txn-queue"
 	}
 
 	iter := r.sc.Find(nil).Select(bson.M{"_id": 1, "txn-queue": 1}).Iter()
 	var stdoc StashTDoc
 	for iter.Next(&stdoc) {
 		for _, txnToken := range stdoc.TxnQueue {
-			txnId := tokenToId(txnToken)
-			if !txnExists(txnId) {
-				logf("WARNING: purging from stash document %s/%v the missing transaction id %s", stdoc.Id.C, stdoc.Id.Id, txnId)
-				if err := pullTxn(r.sc, stdoc.Id, txnId); err != nil {
+			if txnId, ok := tokenToId(txnToken); ok {
+				if !txnExists(txnId) {
+					logf("WARNING: purging from stash document %s/%v the missing transaction id %s",
+						stdoc.Id.C, stdoc.Id.Id, txnId)
+					if err := pullTxn(r.sc, stdoc.Id, txnId); err != nil {
+						return err
+					}
+				}
+			} else {
+				logf("WARNING: purging from stash document %s/%v the invalid transaction token %#v",
+					stdoc.Id.C, stdoc.Id.Id, txnToken)
+				if err := pullToken(r.sc, stdoc.Id, txnToken); err != nil {
 					return err
 				}
 			}
@@ -444,8 +461,26 @@ func (r *Runner) PurgeMissing(collections ...string) error {
 	return nil
 }
 
-func tokenToId(token string) bson.ObjectId {
-	return bson.ObjectIdHex(token[:24])
+var validToken = regexp.MustCompile(`[a-f0-9]{24}_[a-f0-9]{8}`)
+
+func tokenToId(token interface{}) (bson.ObjectId, bool) {
+	tokenStr, ok := token.(string)
+	if !ok {
+		return "", false
+	}
+	if !validToken.MatchString(tokenStr) {
+		return "", false
+	}
+	return bson.ObjectIdHex(tokenStr[:24]), true
+}
+
+func pullToken(collection *mgo.Collection, docId interface{}, token interface{}) error {
+	type M bson.M
+	err := collection.UpdateId(docId, M{"$pullAll": M{"txn-queue": []interface{}{token}}})
+	if err != nil {
+		return fmt.Errorf("error purging invalid token %#v: %v", token, err)
+	}
+	return nil
 }
 
 func pullTxn(collection *mgo.Collection, docId interface{}, txnId bson.ObjectId) error {

--- a/txn/txn_test.go
+++ b/txn/txn_test.go
@@ -564,6 +564,78 @@ func (s *S) TestPurgeMissing(c *C) {
 	}
 }
 
+func (s *S) TestPurgeMissingWithInvalidTxnTokens(c *C) {
+	getQueue := func(coll *mgo.Collection, id interface{}) []interface{} {
+		var doc M
+		err := coll.FindId(id).One(&doc)
+		c.Assert(err, IsNil)
+		return doc["txn-queue"].([]interface{})
+	}
+
+	// Create some documents to mess up.
+	err := s.runner.Run([]txn.Op{
+		{
+			C:      "accounts",
+			Id:     0,
+			Assert: txn.DocMissing,
+			Insert: M{"name": "zero"},
+		}, {
+			C:      "accounts",
+			Id:     1,
+			Assert: txn.DocMissing,
+			Insert: M{"name": "one"},
+		}, {
+			C:      "accounts",
+			Id:     2,
+			Assert: txn.DocMissing,
+			Insert: M{"name": "two"},
+		},
+	}, "", nil)
+	c.Assert(err, IsNil)
+
+	// Remove document 2 so that there's something in the stash.
+	err = s.runner.Run([]txn.Op{{
+		C:      "accounts",
+		Id:     2,
+		Assert: txn.DocExists,
+		Remove: true,
+	}}, "", nil)
+	c.Assert(err, IsNil)
+	doc2StashId := bson.D{{"c", "accounts"}, {"id", 2}}
+
+	// Record the starting txn-queue values.
+	txnQueue0 := getQueue(s.accounts, 0)
+	txnQueue1 := getQueue(s.accounts, 1)
+	txnQueue2 := getQueue(s.sc, doc2StashId)
+
+	// Append some invalid tokens to document 0's txn-queue.
+	err = s.accounts.UpdateId(0, M{"$set": M{
+		"txn-queue": append(txnQueue0, nil, "foo", nil),
+	}})
+	c.Assert(err, IsNil)
+
+	// Prepend some invalid tokens to document 1's txn-queue.
+	err = s.accounts.UpdateId(1, M{"$set": M{
+		"txn-queue": append([]interface{}{"bar", nil}, txnQueue1...),
+	}})
+	c.Assert(err, IsNil)
+
+	// Append bad tokens to the stashed document 2's txn-queue.
+	err = s.sc.UpdateId(doc2StashId, M{"$set": M{
+		"txn-queue": append(txnQueue2, nil, "foo", nil),
+	}})
+	c.Assert(err, IsNil)
+
+	err = s.runner.PurgeMissing("accounts")
+	c.Assert(err, IsNil)
+
+	// Confirm that PurgeMissing removed the bad tokens, restoring the
+	// txn-queue fields back to their starting values.
+	c.Check(txnQueue0, DeepEquals, getQueue(s.accounts, 0))
+	c.Check(txnQueue1, DeepEquals, getQueue(s.accounts, 1))
+	c.Check(txnQueue2, DeepEquals, getQueue(s.sc, doc2StashId))
+}
+
 func (s *S) TestTxnQueueStashStressTest(c *C) {
 	txn.SetChaos(txn.Chaos{
 		SlowdownChance: 0.3,


### PR DESCRIPTION
In at least one (unhappy) real-world situation, nil values have been been observed in the txn-queue fields of documents. These were causing mgo/txn and PurgeMissing itself to panic.

PurgeMissing now detects and removes all obviously invalid txn tokens (including nils).
