### PR TITLE
Add the support of pointer to an array

### DIFF
--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -1055,7 +1055,7 @@ type inlineBadKeyMap struct {
 }
 type inlineUnexported struct {
 	M          map[string]interface{} ",inline"
-	unexported         ",inline"
+	unexported ",inline"
 }
 type unexported struct {
 	A int
@@ -1311,6 +1311,10 @@ var twoWayCrossItems = []crossTypeItem{
 	// arrays
 	{&struct{ V [2]int }{[...]int{1, 2}}, map[string][2]int{"v": [2]int{1, 2}}},
 	{&struct{ V [2]byte }{[...]byte{1, 2}}, map[string][2]byte{"v": [2]byte{1, 2}}},
+
+	// pointer to arrays
+	{&struct{ V *[2]int }{&[2]int{1, 2}}, map[string]*[2]int{"v": &[2]int{1, 2}}},
+	{&struct{ V *[2]byte }{&[2]byte{1, 2}}, map[string]*[2]byte{"v": &[2]byte{1, 2}}},
 
 	// zero time
 	{&struct{ V time.Time }{}, map[string]interface{}{"v": time.Time{}}},


### PR DESCRIPTION
Add the support of pointer to an array (not slice).

Until now, we could save something like &struct{ V *[2]int }, but we had an error when the object was retrieved ( &reflect.ValueError{Method:"reflect.Value.Len", Kind:0x16} ).
