### PR TITLE
Add a Iter.Done function for determining if an Iter is exhausted

### DIFF
--- a/session.go
+++ b/session.go
@@ -2332,7 +2332,7 @@ type queryError struct {
 	ErrMsg        string
 	Assertion     string
 	Code          int
-	AssertionCode int        "assertionCode"
+	AssertionCode int "assertionCode"
 }
 
 type QueryError struct {
@@ -3548,6 +3548,40 @@ func (iter *Iter) Close() error {
 	}
 	iter.m.Unlock()
 	return err
+}
+
+// Done returns true if there will never be more results from this
+// cursor, and false if it's possible that there will be more
+// results. For a standard (non-tailing) query, this returns false if
+// calling Next would return true. For tailable cursors, it's somewhat
+// more complicated - this may return false even if there are no
+// immediate results, so long as there might be results later.
+//
+// If the Iter is waiting for results from the server, Done may
+// block.
+func (iter *Iter) Done() bool {
+	iter.m.Lock()
+	defer iter.m.Unlock()
+
+	for {
+		if iter.docData.Len() > 0 {
+			return false
+		}
+
+		if iter.err != nil {
+			return true
+		}
+
+		// If we're waiting for a reply from an in-flight
+		// query, wait until we know whether or not there's
+		// still a cursor ID.
+		if iter.docsToReceive > 0 {
+			iter.gotReply.Wait()
+			continue
+		}
+
+		return iter.op.cursorId == 0
+	}
 }
 
 // Timeout returns true if Next returned false due to a timeout of


### PR DESCRIPTION
We would like to know if an Iter has been exhausted, or if it will have additional results. An Iter may have additional results either if there are more results cached locally, or if we have a non-0 cursor ID. (When mongod returns the last batch of results, it returns a cursor ID of 0).

Conceivably, you could determine this by calling Next and just storing the result until you actually need it, but that's annoying. This is simpler.

The semantics for tail cursors are a bit more complicated (since conceivably you could call HaveMore() and get true, but then call Next() and get false), but tail cursors were always complicated.

I'm not wedded to this specific API, but I would like some way to "peek" at whether there are more results coming down the line. Thoughts?
