### PR TITLE
Add lazy check connection after session creation

### DIFF
--- a/session.go
+++ b/session.go
@@ -315,6 +315,7 @@ func ParseURL(url string) (*DialInfo, error) {
 		Source:         source,
 		PoolLimit:      poolLimit,
 		ReplicaSetName: setName,
+		LazyConn:       false,
 	}
 	return &info, nil
 }
@@ -387,6 +388,10 @@ type DialInfo struct {
 
 	// WARNING: This field is obsolete. See DialServer above.
 	Dial func(addr net.Addr) (net.Conn, error)
+
+	// LazyConn controls wether connection to the server should be delayed
+	// (true value) or should connect to the server inmediatly (false value).
+	LazyConn bool
 }
 
 // mgo.v3: Drop DialInfo.Dial.
@@ -457,9 +462,11 @@ func DialWithInfo(info *DialInfo) (*Session, error) {
 	// established to any servers yet (e.g. what if url was wrong). So,
 	// ping the server to ensure there's someone there, and abort if it
 	// fails.
-	if err := session.Ping(); err != nil {
-		session.Close()
-		return nil, err
+	if !info.LazyConn {
+		if err := session.Ping(); err != nil {
+			session.Close()
+			return nil, err
+		}
 	}
 	session.SetMode(Strong, true)
 	return session, nil

--- a/session_test.go
+++ b/session_test.go
@@ -107,6 +107,31 @@ func (s *S) TestURLSingle(c *C) {
 	c.Assert(result.Ok, Equals, 1)
 }
 
+func (s *S) TestLazyConn(c *C) {
+	s.Stop(":40002")
+	info, err := mgo.ParseURL("mongodb://localhost:40002/")
+	c.Assert(err, IsNil)
+
+	info.LazyConn = true
+	info.Timeout = 100 * time.Millisecond
+
+	sess, err := mgo.DialWithInfo(info)
+	defer func() {
+		sess.Close()
+		s.StartAll()
+	}()
+	c.Assert(err, IsNil)
+
+	err = sess.Ping()
+	c.Assert(err, NotNil)
+
+	s.StartAll()
+	time.Sleep(200 * time.Millisecond)
+
+	err = sess.Ping()
+	c.Assert(err, IsNil)
+}
+
 func (s *S) TestURLMany(c *C) {
 	session, err := mgo.Dial("mongodb://localhost:40011,localhost:40012/")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Currently one of the last steps that `mgo` driver performs after a session is being created is to check if the connection can be established, returning an error otherwise.

As documented in the code:

```
// People get confused when we return a session that is not actually
// established to any servers yet (e.g. what if url was wrong). So,
// ping the server to ensure there's someone there, and abort if it
// fails.
```

I'd like to disable this behaviour in some situations: for example, dealing with microservices is very annoying not being able to start an application if the Mongo server is not available.

Fortunately, seems that `mgo` code was able to delay the connection, perhaps using the same mechanism that it's using to perform reconnections.

In this PR I'm proposing to introduce a new config parameter to `DialInfo` called `LazyConn` to avoid checking the connection (_pinging_ the server). If not defined the behaviour is backward compatible with previous versions: aborting the session creation if the connection cannot be established.

Sample (simplified) usage:

``` go
info, _ := mgo.ParseURL("mongodb://localhost:40002/")
info.LazyConn = true
sess, _ := mgo.DialWithInfo(info) // session created without checking the connection
```
