### PR TITLE
dont mix input and output buffers in cgo calls

### DIFF
--- a/internal/sasl/sasl_windows.c
+++ b/internal/sasl/sasl_windows.c
@@ -17,7 +17,7 @@ SECURITY_STATUS SEC_ENTRY sspi_acquire_credentials_handle(CredHandle *cred_handl
 	return call_sspi_acquire_credentials_handle(NULL, SSPI_PACKAGE_NAME, SECPKG_CRED_OUTBOUND, NULL, &auth_identity, NULL, NULL, cred_handle, &ignored);
 }
 
-int sspi_step(CredHandle *cred_handle, int has_context, CtxtHandle *context, PVOID *buffer, ULONG *buffer_length, char *target)
+int sspi_step(CredHandle *cred_handle, int has_context, CtxtHandle *context, PVOID buffer, ULONG buffer_length, PVOID *out_buffer, ULONG *out_buffer_length,  char *target)
 {
 	SecBufferDesc inbuf;
 	SecBuffer in_bufs[1];
@@ -30,8 +30,8 @@ int sspi_step(CredHandle *cred_handle, int has_context, CtxtHandle *context, PVO
 		inbuf.ulVersion = SECBUFFER_VERSION;
 		inbuf.cBuffers = 1;
 		inbuf.pBuffers = in_bufs;
-		in_bufs[0].pvBuffer = *buffer;
-		in_bufs[0].cbBuffer = *buffer_length;
+		in_bufs[0].pvBuffer = buffer;
+		in_bufs[0].cbBuffer = buffer_length;
 		in_bufs[0].BufferType = SECBUFFER_TOKEN;
 	}
 
@@ -57,9 +57,9 @@ int sspi_step(CredHandle *cred_handle, int has_context, CtxtHandle *context, PVO
 	          &context_attr,
 	          NULL);
 
-	*buffer = malloc(out_bufs[0].cbBuffer);
-	*buffer_length = out_bufs[0].cbBuffer;
-	memcpy(*buffer, out_bufs[0].pvBuffer, *buffer_length);
+	*out_buffer = malloc(out_bufs[0].cbBuffer);
+	*out_buffer_length = out_bufs[0].cbBuffer;
+	memcpy(*out_buffer, out_bufs[0].pvBuffer, *out_buffer_length);
 
 	return ret;
 }

--- a/internal/sasl/sasl_windows.h
+++ b/internal/sasl/sasl_windows.h
@@ -3,5 +3,5 @@
 #include "sspi_windows.h"
 
 SECURITY_STATUS SEC_ENTRY sspi_acquire_credentials_handle(CredHandle* cred_handle, char* username, char* password, char* domain);
-int sspi_step(CredHandle* cred_handle, int has_context, CtxtHandle* context, PVOID* buffer, ULONG* buffer_length, char* target);
+int sspi_step(CredHandle* cred_handle, int has_context, CtxtHandle* context, PVOID buffer, ULONG buffer_length, PVOID* out_buffer, ULONG* out_buffer_length, char* target);
 int sspi_send_client_authz_id(CtxtHandle* context, PVOID* buffer, ULONG* buffer_length, char* user_plus_realm);


### PR DESCRIPTION
This is just a backport from v2-unstable. Since the code in v2 always fails on windows under 1.6, this should be fixed sooner then later. If a merge from v2-unstable is upcoming, then discard this pull request.
