### PR TITLE
Increase bson.NewObjectId() performance by caching the process id

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -205,6 +205,7 @@ func readRandomUint32() uint32 {
 // machineId stores machine id generated once and used in subsequent calls
 // to NewObjectId function.
 var machineId = readMachineId()
+var processId = os.Getpid()
 
 // readMachineId generates and returns a machine id.
 // If this function fails to get the hostname it will cause a runtime error.
@@ -235,9 +236,8 @@ func NewObjectId() ObjectId {
 	b[5] = machineId[1]
 	b[6] = machineId[2]
 	// Pid, 2 bytes, specs don't specify endianness, but we use big endian.
-	pid := os.Getpid()
-	b[7] = byte(pid >> 8)
-	b[8] = byte(pid)
+	b[7] = byte(processId >> 8)
+	b[8] = byte(processId)
 	// Increment, 3 bytes, big endian
 	i := atomic.AddUint32(&objectIdCounter, 1)
 	b[9] = byte(i >> 16)

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -1824,3 +1824,9 @@ func (s *S) BenchmarkUnmarshalRaw(c *C) {
 		panic(err)
 	}
 }
+
+func (s *S) BenchmarkNewObjectId(c *C) {
+	for i := 0; i < c.N; i++ {
+		bson.NewObjectId()
+	}
+}


### PR DESCRIPTION
Every call to `bson.NewObjectId()` will also call `syscall.Getpid()` to obtain the process id. This PR caches the id and increases the performance:

```
Before:
PASS: bson_test.go:1828: S.BenchmarkNewObjectId 10000000  228 ns/op

After:
PASS: bson_test.go:1828: S.BenchmarkNewObjectId 20000000 76.0 ns/op
```

AFAIK go does not support process forking, the process id should therefore always be the same.

I noticed this while working on a system that writes a lot of data to the database and generates the ObjectId on the client. This PR significantly increases the performance of the said system.
