### PR TITLE
Fix SetCursorTimeout. See https://jira.mongodb.org/browse/SERVER-24899

### DIFF
--- a/session.go
+++ b/session.go
@@ -1581,7 +1581,7 @@ func (s *Session) Refresh() {
 }
 
 // SetMode changes the consistency mode for the session.
-// 
+//
 // The default mode is Strong.
 //
 // In the Strong consistency mode reads and writes will always be made to
@@ -3086,18 +3086,21 @@ func prepareFindOp(socket *mongoSocket, op *queryOp, limit int32) bool {
 	}
 
 	find := findCmd{
-		Collection:  op.collection[nameDot+1:],
-		Filter:      op.query,
-		Projection:  op.selector,
-		Sort:        op.options.OrderBy,
-		Skip:        op.skip,
-		Limit:       limit,
-		MaxTimeMS:   op.options.MaxTimeMS,
-		MaxScan:     op.options.MaxScan,
-		Hint:        op.options.Hint,
-		Comment:     op.options.Comment,
-		Snapshot:    op.options.Snapshot,
-		OplogReplay: op.flags&flagLogReplay != 0,
+		Collection:      op.collection[nameDot+1:],
+		Filter:          op.query,
+		Projection:      op.selector,
+		Sort:            op.options.OrderBy,
+		Skip:            op.skip,
+		Limit:           limit,
+		MaxTimeMS:       op.options.MaxTimeMS,
+		MaxScan:         op.options.MaxScan,
+		Hint:            op.options.Hint,
+		Comment:         op.options.Comment,
+		Snapshot:        op.options.Snapshot,
+		Tailable:        op.flags&flagTailable != 0,
+		AwaitData:       op.flags&flagAwaitData != 0,
+		OplogReplay:     op.flags&flagLogReplay != 0,
+		NoCursorTimeout: op.flags&flagNoCursorTimeout != 0,
 	}
 	if op.limit < 0 {
 		find.BatchSize = -op.limit


### PR DESCRIPTION
`Tailable`, `AwaitData`, and `NoCursorTimeout` were not set, and for some reason MongoDB has two copies of each flag. And it was looking at the other set.
