### PR TITLE
add ssl detection to ParseURL and test accordingly

### DIFF
--- a/session.go
+++ b/session.go
@@ -279,6 +279,7 @@ func ParseURL(url string) (*DialInfo, error) {
 	source := ""
 	setName := ""
 	poolLimit := 0
+	ssl := false
 	for k, v := range uinfo.options {
 		switch k {
 		case "authSource":
@@ -302,6 +303,15 @@ func ParseURL(url string) (*DialInfo, error) {
 			if v == "replicaSet" {
 				break
 			}
+			return nil, errors.New("unsupported connection URL option: " + k + "=" + v)
+		case "ssl":
+			if v == "true" {
+				ssl = true
+				break
+			}
+			if v == "false" {
+				break
+			}
 			fallthrough
 		default:
 			return nil, errors.New("unsupported connection URL option: " + k + "=" + v)
@@ -318,6 +328,7 @@ func ParseURL(url string) (*DialInfo, error) {
 		Source:         source,
 		PoolLimit:      poolLimit,
 		ReplicaSetName: setName,
+		SSL:            ssl,
 	}
 	return &info, nil
 }
@@ -390,6 +401,9 @@ type DialInfo struct {
 
 	// WARNING: This field is obsolete. See DialServer above.
 	Dial func(addr net.Addr) (net.Conn, error)
+
+	// If the connection url indicated an ssl connection should be used
+	SSL bool
 }
 
 // mgo.v3: Drop DialInfo.Dial.
@@ -1584,7 +1598,7 @@ func (s *Session) Refresh() {
 }
 
 // SetMode changes the consistency mode for the session.
-// 
+//
 // The default mode is Strong.
 //
 // In the Strong consistency mode reads and writes will always be made to

--- a/session_test.go
+++ b/session_test.go
@@ -130,6 +130,21 @@ func (s *S) TestURLParsing(c *C) {
 		}
 		c.Assert(err, ErrorMatches, "unsupported connection URL option: (foo=1|bar=2)")
 	}
+
+	sslUrls := map[string]bool{
+		"localhost:40001?ssl=true":  true,
+		"localhost:40001?ssl=false": false,
+	}
+	for url, expectedValue := range sslUrls {
+		info, err := mgo.ParseURL(url)
+		c.Assert(info.SSL, Equals, expectedValue)
+		c.Assert(err, IsNil)
+	}
+
+	invalidSSLUrl := "localhost:40001?ssl=vinDiesel"
+	info, err := mgo.ParseURL(invalidSSLUrl)
+	c.Assert(info, IsNil)
+	c.Assert(err, ErrorMatches, "unsupported connection URL option: ssl=vinDiesel")
 }
 
 func (s *S) TestInsertFindOne(c *C) {
@@ -4159,11 +4174,11 @@ func (s *S) TestBypassValidation(c *C) {
 
 func (s *S) TestVersionAtLeast(c *C) {
 	tests := [][][]int{
-		{{3,2,1}, {3,2,0}},
-		{{3,2,1}, {3,2}},
-		{{3,2,1}, {2,5,5,5}},
-		{{3,2,1}, {2,5,5}},
-		{{3,2,1}, {2,5}},
+		{{3, 2, 1}, {3, 2, 0}},
+		{{3, 2, 1}, {3, 2}},
+		{{3, 2, 1}, {2, 5, 5, 5}},
+		{{3, 2, 1}, {2, 5, 5}},
+		{{3, 2, 1}, {2, 5}},
 	}
 	for _, pair := range tests {
 		bi := mgo.BuildInfo{VersionArray: pair[0]}


### PR DESCRIPTION
This would be a pre-requisite to extending mgo with baked in PEM support etc... but also avoids users having to separately parse their urls to see if connection string uses SSL.

I'd like to keep working on this but:
1) I'm unclear on the scope of mgo - is a TLS dialer, pem reading/parsing something you'd like to include (I've seen other libraries have a pemFilePath url param)?
2) I'm having issues getting the test suite to run and as such my tests here are speculative
here's my supervisord output http://pastebin.com/GqEGFc60
