### PR TITLE
Add an iter.NeedsNetwork function

### DIFF
--- a/session.go
+++ b/session.go
@@ -3649,6 +3649,22 @@ func (iter *Iter) Done() bool {
 	}
 }
 
+// NeedsNetwork returns true if only if a follow up Next call will issue
+// a getMore operation to mongo
+func (iter *Iter) NeedsNetwork() bool {
+	iter.m.Lock()
+	defer iter.m.Unlock()
+
+	if iter.err != nil || iter.op.cursorId == 0 {
+		return false
+	} else if iter.docData.Len() == 0 && iter.docsToReceive == 0 {
+		return true
+	} else if iter.docsBeforeMore == 0 { // prefetch
+		return true
+	}
+	return false
+}
+
 // Timeout returns true if Next returned false due to a timeout of
 // a tailable cursor. In those cases, Next may be called again to continue
 // the iteration at the previous cursor position.

--- a/session_test.go
+++ b/session_test.go
@@ -1351,6 +1351,7 @@ func (s *S) TestFindIterNotFound(c *C) {
 	ok := iter.Next(&result)
 	c.Assert(ok, Equals, false)
 	c.Assert(iter.Err(), IsNil)
+	c.Assert(iter.Done(), Equals, true)
 }
 
 func (s *S) TestFindNil(c *C) {
@@ -4014,20 +4015,6 @@ func (s *S) TestFindIterDoneErr(c *C) {
 	c.Assert(iter.Err(), ErrorMatches, "unauthorized.*|not authorized.*")
 }
 
-func (s *S) TestFindIterDoneNotFound(c *C) {
-	session, err := mgo.Dial("localhost:40001")
-	c.Assert(err, IsNil)
-	defer session.Close()
-
-	coll := session.DB("mydb").C("mycoll")
-
-	result := struct{ A, B int }{}
-	iter := coll.Find(M{"a": 1}).Iter()
-	ok := iter.Next(&result)
-	c.Assert(ok, Equals, false)
-	c.Assert(iter.Done(), Equals, true)
-}
-
 func (s *S) TestLogReplay(c *C) {
 	session, err := mgo.Dial("localhost:40001")
 	c.Assert(err, IsNil)
@@ -4159,11 +4146,11 @@ func (s *S) TestBypassValidation(c *C) {
 
 func (s *S) TestVersionAtLeast(c *C) {
 	tests := [][][]int{
-		{{3,2,1}, {3,2,0}},
-		{{3,2,1}, {3,2}},
-		{{3,2,1}, {2,5,5,5}},
-		{{3,2,1}, {2,5,5}},
-		{{3,2,1}, {2,5}},
+		{{3, 2, 1}, {3, 2, 0}},
+		{{3, 2, 1}, {3, 2}},
+		{{3, 2, 1}, {2, 5, 5, 5}},
+		{{3, 2, 1}, {2, 5, 5}},
+		{{3, 2, 1}, {2, 5}},
 	}
 	for _, pair := range tests {
 		bi := mgo.BuildInfo{VersionArray: pair[0]}


### PR DESCRIPTION
We have a tailable cursor of a capped collection with lots of inserts. Right now, using a `for tail.Next(&result) {...}` mgo issue roughly one getmore request per insert, which means our mongod instance can get 100s of getmores per second.

We'd like a way to tell mgo to wait a little before issuing a getmore so we can "batch" documents together. Adding a `iter.NeedsNetwork` function, which tells us whether the next `iter.Next` call will issue a getmore request seemed the like easiest way to do this.

I'm not attached to the API or the name, but I'd like some way to cut down on the number of requests mgo issues.
