### PR TITLE
Added "PartialFilterExpression" support to Indexes.

### DIFF
--- a/session.go
+++ b/session.go
@@ -1011,7 +1011,7 @@ type indexSpec struct {
 	DefaultLanguage  string  "default_language,omitempty"
 	LanguageOverride string  "language_override,omitempty"
 	TextIndexVersion int     "textIndexVersion,omitempty"
-
+	PartialFilterExpression  bson.M "partialFilterExpression,omitempty"
 	Collation *Collation "collation,omitempty"
 }
 
@@ -1021,6 +1021,7 @@ type Index struct {
 	DropDups   bool     // Drop documents with the same index key as a previously indexed one
 	Background bool     // Build index in background and return immediately
 	Sparse     bool     // Only index documents containing the Key fields
+	PartialFilterExpression bson.M //If specified, the index only references documents that match the filter expression
 
 	// If ExpireAfter is defined the server will periodically delete
 	// documents with indexed time.Time older than the provided delta.
@@ -1284,6 +1285,7 @@ func (c *Collection) EnsureIndex(index Index) error {
 		DropDups:         index.DropDups,
 		Background:       index.Background,
 		Sparse:           index.Sparse,
+		PartialFilterExpression: index.PartialFilterExpression,
 		Bits:             index.Bits,
 		Min:              index.Minf,
 		Max:              index.Maxf,
@@ -1494,20 +1496,21 @@ func (c *Collection) Indexes() (indexes []Index, err error) {
 
 func indexFromSpec(spec indexSpec) Index {
 	index := Index{
-		Name:             spec.Name,
-		Key:              simpleIndexKey(spec.Key),
-		Unique:           spec.Unique,
-		DropDups:         spec.DropDups,
-		Background:       spec.Background,
-		Sparse:           spec.Sparse,
-		Minf:             spec.Min,
-		Maxf:             spec.Max,
-		Bits:             spec.Bits,
-		BucketSize:       spec.BucketSize,
-		DefaultLanguage:  spec.DefaultLanguage,
-		LanguageOverride: spec.LanguageOverride,
-		ExpireAfter:      time.Duration(spec.ExpireAfter) * time.Second,
-		Collation:        spec.Collation,
+		Name:                    spec.Name,
+		Key:                     simpleIndexKey(spec.Key),
+		Unique:                  spec.Unique,
+		DropDups:                spec.DropDups,
+		Background:              spec.Background,
+		Sparse:                  spec.Sparse,
+		Minf:                    spec.Min,
+		Maxf:                    spec.Max,
+		Bits:                    spec.Bits,
+		BucketSize:              spec.BucketSize,
+		DefaultLanguage:         spec.DefaultLanguage,
+		LanguageOverride:        spec.LanguageOverride,
+		ExpireAfter:             time.Duration(spec.ExpireAfter) * time.Second,
+		Collation:               spec.Collation,
+		PartialFilterExpression: spec.PartialFilterExpression,
 	}
 	if float64(int(spec.Min)) == spec.Min && float64(int(spec.Max)) == spec.Max {
 		index.Min = int(spec.Min)

--- a/session_test.go
+++ b/session_test.go
@@ -2955,6 +2955,21 @@ var indexTests = []struct {
 		"key":  M{"cn": 1},
 		"ns":   "mydb.mycoll",
 	},
+}, {
+	mgo.Index{
+		Key:        []string{"p"},
+		Unique: true,
+		PartialFilterExpression: bson.M{
+			"p": bson.M{"$exists": true},
+		},
+	},
+	M{
+		"name":       "p_1",
+		"key":        M{"p": 1},
+		"ns":         "mydb.mycoll",
+		"unique":   true,
+		"partialFilterExpression": M{"p" : M{"$exists" : true}},
+	},
 }}
 
 func (s *S) TestEnsureIndex(c *C) {


### PR DESCRIPTION
If specified, the index only references documents that match the filter expression.

Should resolve #284 as I need support for partial indexes.
