### PR TITLE
Encoding and decoding of interfaces

### DIFF
--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -1139,6 +1139,41 @@ func parseURL(s string) *url.URL {
 	return u
 }
 
+type World struct {
+	People []Person
+}
+
+type Person struct {
+	Name string
+	Age  int
+	Beh  Behaviour
+	//More..
+}
+
+type Behaviour interface {
+	DoSomething()
+}
+
+type Walk struct {
+	X int
+	Y int
+}
+
+func (w Walk) DoSomething() {
+}
+
+func (s Speak) DoSomething() {
+}
+
+type Speak struct {
+	Text string
+}
+
+func init() {
+	bson.Register(Walk{})
+	bson.Register(Speak{})
+}
+
 // That's a pretty fun test.  It will dump the first item, generate a zero
 // value equivalent to the second one, load the dumped data onto it, and then
 // verify that the resulting value is deep-equal to the untouched second value.
@@ -1346,6 +1381,7 @@ var twoWayCrossItems = []crossTypeItem{
 
 	// Interface slice setter.
 	{&struct{ V ifaceSlice }{ifaceSlice{nil, nil, nil}}, bson.M{"v": []interface{}{3}}},
+	{&World{People: []Person{{Name: "John", Age: 30, Beh: Walk{X: 10, Y: 20}}, {Name: "Mike", Age: 25, Beh: Speak{"Hi!"}}}}, &World{People: []Person{{Name: "John", Age: 30, Beh: Walk{X: 10, Y: 20}}, {Name: "Mike", Age: 25, Beh: Speak{"Hi!"}}}}},
 }
 
 // Same thing, but only one way (obj1 => obj2).

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -263,7 +263,22 @@ func (e *encoder) addElem(name string, v reflect.Value, minSize bool) {
 	switch v.Kind() {
 
 	case reflect.Interface:
-		e.addElem(name, v.Elem(), minSize)
+		child := v.Elem()
+		if child.Kind() == reflect.Struct {
+			ut, _ := getStructInfo(child.Type())
+			childname, ok := concreteTypeToName[ut.base]
+			if !ok || childname == name {
+				e.addElem(name, v.Elem(), minSize)
+			} else {
+				e.addElemName(0x03, name)
+
+				m := M{childname: child.Interface()}
+
+				e.addDoc(reflect.ValueOf(m))
+			}
+		} else {
+			e.addElem(name, v.Elem(), minSize)
+		}
 
 	case reflect.Ptr:
 		e.addElem(name, v.Elem(), minSize)


### PR DESCRIPTION
This PR allows encoding and decoding of interfaces with bson without having to write a getter/setter. 
It works pretty much the same as gob, you'll first have to register the implementing class with `bson.Register`. If an interface is not registered, it will be encoded exactly as before.