### PR TITLE
Update sasl.go

### DIFF
--- a/internal/sasl/sasl.go
+++ b/internal/sasl/sasl.go
@@ -3,7 +3,7 @@
 // This package is not meant to be used by itself.
 //
 
-// +build !windows
+// +build !windows,!heroku
 
 package sasl
 


### PR DESCRIPTION
In heroku, build failed like below.
remote: vendor/gopkg.in/mgo.v2/internal/sasl/sasl.go:15:24: fatal error: sasl/sasl.h: No such file or directory
remote:  // #include <sasl/sasl.h>

So I just append build option to sasl.go file like this,
// +build !windows,!heroku

Then it works!