### PR TITLE
txn: return error from flusher.checkpoint

### DIFF
--- a/txn/flusher.go
+++ b/txn/flusher.go
@@ -691,7 +691,7 @@ func (f *flusher) checkpoint(t *transaction, revnos []int64) error {
 		f.debugf("Ready to apply %s. Saving revnos %v: LOST RACE", t, debugRevnos)
 		return f.reload(t)
 	}
-	return nil
+	return err
 }
 
 func (f *flusher) apply(t *transaction, pull map[bson.ObjectId]*transaction) error {


### PR DESCRIPTION
If the call to f.tc.Update in flusher.checkpoint
fails due to an error other than mgo.ErrNotFound,
the error is currently swallowed. flusher.advance
will then loop back around and call checkpoint
again, which may continue to fail (e.g. if the
Mongo connection is in a bad state), pegging the
CPU.