### PR TITLE
Add support for Partial indexes

### DIFF
--- a/session.go
+++ b/session.go
@@ -1515,6 +1515,7 @@ func indexFromSpec(spec indexSpec) Index {
 		LanguageOverride: spec.LanguageOverride,
 		ExpireAfter:      time.Duration(spec.ExpireAfter) * time.Second,
 		Collation:        spec.Collation,
+		PartialFilter:    spec.PartialFilterExpression,
 	}
 	if float64(int(spec.Min)) == spec.Min && float64(int(spec.Max)) == spec.Max {
 		index.Min = int(spec.Min)

--- a/session_test.go
+++ b/session_test.go
@@ -2975,6 +2975,19 @@ var indexTests = []struct {
 		"key":  M{"cn": 1},
 		"ns":   "mydb.mycoll",
 	},
+}, {
+	mgo.Index{
+		Key: []string{"a"},
+		PartialFilter: bson.M{
+			"b": bson.M{"$gt": 42},
+		},
+	},
+	M{
+		"name":       "a_1",
+		"key":        M{"a": 1},
+		"ns":         "mydb.mycoll",
+		"background": true,
+	},
 }}
 
 func (s *S) TestEnsureIndex(c *C) {

--- a/session_test.go
+++ b/session_test.go
@@ -2977,16 +2977,18 @@ var indexTests = []struct {
 	},
 }, {
 	mgo.Index{
-		Key: []string{"a"},
+		Key: []string{"partial"},
 		PartialFilter: bson.M{
 			"b": bson.M{"$gt": 42},
 		},
 	},
 	M{
-		"name":       "a_1",
-		"key":        M{"a": 1},
-		"ns":         "mydb.mycoll",
-		"background": true,
+		"name": "partial_1",
+		"ns":   "mydb.mycoll",
+		"partialFilterExpression": M{
+			"b": M{"$gt": 42},
+		},
+		"key": M{"partial": 1},
 	},
 }}
 
@@ -3000,6 +3002,11 @@ func (s *S) TestEnsureIndex(c *C) {
 
 	for _, test := range indexTests {
 		if !s.versionAtLeast(2, 4) && test.expected["textIndexVersion"] != nil {
+			continue
+		}
+
+		// Only test partial indexes on
+		if !s.versionAtLeast(3, 2) && test.expected["name"] == "partial_1" {
 			continue
 		}
 


### PR DESCRIPTION
Fixes #284 

Adds support for creating partial indexes in MongoDB 3.2+ and supports returning the filter when calling `Indexes()` on a collection.