### PR TITLE
update: Fix bulkUpdate and bulkDelete handle error

### DIFF
--- a/bulk_test.go
+++ b/bulk_test.go
@@ -317,6 +317,28 @@ func (s *S) TestBulkUpdate(c *C) {
 	c.Assert(res, DeepEquals, []doc{{10}, {20}, {30}})
 }
 
+func (s *S) TestBulkUpdateOver1000(c *C) {
+	session, err := mgo.Dial("localhost:40001")
+	c.Assert(err, IsNil)
+	defer session.Close()
+
+	coll := session.DB("mydb").C("mycoll")
+
+	bulk := coll.Bulk()
+	for i := 0; i < 1010; i++ {
+		bulk.Insert(M{"n": i})
+	}
+	_, err = bulk.Run()
+	c.Assert(err, IsNil)
+	bulk = coll.Bulk()
+	for i := 0; i < 1010; i++ {
+		bulk.Update(M{"n": i}, M{"$set": M{"m": i}})
+	}
+	// if not handle well, mongo will return error here
+	_, err = bulk.Run()
+	c.Assert(err, IsNil)
+}
+
 func (s *S) TestBulkUpdateError(c *C) {
 	session, err := mgo.Dial("localhost:40001")
 	c.Assert(err, IsNil)

--- a/session.go
+++ b/session.go
@@ -2776,8 +2776,7 @@ func (q *Query) Limit(n int) *Query {
 	switch {
 	case n == 1:
 		q.limit = 1
-		// Modify by Ray
-		q.op.limit = 1
+		q.op.limit = -1
 	case n == math.MinInt32: // -MinInt32 == -MinInt32
 		q.limit = math.MaxInt32
 		q.op.limit = math.MinInt32 + 1

--- a/session.go
+++ b/session.go
@@ -4647,8 +4647,10 @@ func (c *Collection) writeOp(op interface{}, ordered bool) (lerr *LastError, err
 			var lerr LastError
 			for i, updateOp := range updateOps {
 				oplerr, err := c.writeOpQuery(socket, safeOp, updateOp, ordered)
-				lerr.N += oplerr.N
-				lerr.modified += oplerr.modified
+				if oplerr != nil {
+					lerr.N += oplerr.N
+					lerr.modified += oplerr.modified
+				}
 				if err != nil {
 					lerr.ecases = append(lerr.ecases, BulkErrorCase{i, err})
 					if ordered {
@@ -4665,8 +4667,10 @@ func (c *Collection) writeOp(op interface{}, ordered bool) (lerr *LastError, err
 			var lerr LastError
 			for i, deleteOp := range deleteOps {
 				oplerr, err := c.writeOpQuery(socket, safeOp, deleteOp, ordered)
-				lerr.N += oplerr.N
-				lerr.modified += oplerr.modified
+				if oplerr != nil {
+					lerr.N += oplerr.N
+					lerr.modified += oplerr.modified
+				}
 				if err != nil {
 					lerr.ecases = append(lerr.ecases, BulkErrorCase{i, err})
 					if ordered {

--- a/session.go
+++ b/session.go
@@ -41,7 +41,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DroiTaipei/mgo/bson"
+	"gopkg.in/mgo.v2-unstable/bson"
 )
 
 type Mode int


### PR DESCRIPTION
Hi, this PR fixes the bug in collection.writeOp of bulkUpdate/bulkDelete. 
This is also related to #288 . The bulk size of bulk.Update/Delete over 1000 will receive the error message from mongodb.