### PR TITLE
Configurable near ping threshold

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -578,7 +578,7 @@ func (cluster *mongoCluster) syncServersIteration(direct bool) {
 // AcquireSocket returns a socket to a server in the cluster.  If slaveOk is
 // true, it will attempt to return a socket to a slave server.  If it is
 // false, the socket will necessarily be to a master server.
-func (cluster *mongoCluster) AcquireSocket(mode Mode, slaveOk bool, syncTimeout time.Duration, socketTimeout time.Duration, serverTags []bson.D, poolLimit int) (s *mongoSocket, err error) {
+func (cluster *mongoCluster) AcquireSocket(mode Mode, slaveOk bool, syncTimeout time.Duration, socketTimeout time.Duration, serverTags []bson.D, poolLimit int, pingNearThreshold time.Duration) (s *mongoSocket, err error) {
 	var started time.Time
 	var syncCount uint
 	warnedLimit := false
@@ -611,9 +611,9 @@ func (cluster *mongoCluster) AcquireSocket(mode Mode, slaveOk bool, syncTimeout 
 
 		var server *mongoServer
 		if slaveOk {
-			server = cluster.servers.BestFit(mode, serverTags)
+			server = cluster.servers.BestFit(mode, serverTags, pingNearThreshold)
 		} else {
-			server = cluster.masters.BestFit(mode, nil)
+			server = cluster.masters.BestFit(mode, nil, pingNearThreshold)
 		}
 		cluster.RUnlock()
 

--- a/server.go
+++ b/server.go
@@ -413,7 +413,7 @@ func (servers *mongoServers) HasMongos() bool {
 
 // BestFit returns the best guess of what would be the most interesting
 // server to perform operations on at this point in time.
-func (servers *mongoServers) BestFit(mode Mode, serverTags []bson.D) *mongoServer {
+func (servers *mongoServers) BestFit(mode Mode, serverTags []bson.D, pingNearThreshold time.Duration) *mongoServer {
 	var best *mongoServer
 	for _, next := range servers.slice {
 		if best == nil {
@@ -435,7 +435,7 @@ func (servers *mongoServers) BestFit(mode Mode, serverTags []bson.D) *mongoServe
 		case next.info.Master != best.info.Master && mode != Nearest:
 			// Prefer slaves, unless the mode is PrimaryPreferred.
 			swap = (mode == PrimaryPreferred) != best.info.Master
-		case absDuration(next.pingValue-best.pingValue) > 15*time.Millisecond:
+		case absDuration(next.pingValue-best.pingValue) > pingNearThreshold:
 			// Prefer nearest server.
 			swap = next.pingValue < best.pingValue
 		case len(next.liveSockets)-len(next.unusedSockets) < len(best.liveSockets)-len(best.unusedSockets):


### PR DESCRIPTION
During load tests, when firing a lot of queries against a replica-set one of the servers will be detected not to be near (15ms) in BestFit-method.  
This leads to a swap of all queries to the seconds slave which subsequently will become slow as well.  
After the next cluster sync the load will swap to the first slave again and some kind of ping-pong balancing occurs.
To fine-tune the BestFit-Method I implemented an option to overwrite the near-threshold for the session.

I'd like to hear your opinion on this change.