### PR TITLE
Fallback json tag incase bson was not defined

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -714,7 +714,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 		if tag != "" {
 			info.Key = tag
 		} else {
-			info.Key = strings.ToLower(field.Name)
+			info.Key = getJSONTag(field)
 		}
 
 		if _, found = fieldsMap[info.Key]; found {
@@ -735,4 +735,13 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 	structMap[st] = sinfo
 	structMapMutex.Unlock()
 	return sinfo, nil
+}
+
+func getJSONTag(field reflect.StructField) string {
+	tag := field.Tag.Get("json")
+	if tag == "" {
+		return strings.ToLower(field.Name)
+	}
+	// should we behave json "omitempty","-"... the same for bson?
+	return tag
 }


### PR DESCRIPTION
The thing is that:
- If the structure that we are using already defined JSON tag in some ext-libs, we can not modify it but we want to keep the same JSON structure that they already defined.
- MongoDB originally stores data under JSON document object, then JSON should be the backup of BSON tag in case people did not/could not define in structure.
