### PR TITLE
refactor: By linter: aligncheck and gosimple for better memory use

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1477,7 +1477,6 @@ func (s *S) TestSecondaryModeWithMongosInsert(c *C) {
 	c.Assert(result.A, Equals, 1)
 }
 
-
 func (s *S) TestRemovalOfClusterMember(c *C) {
 	if *fast {
 		c.Skip("-fast")
@@ -1584,7 +1583,7 @@ func (s *S) TestPoolLimitSimple(c *C) {
 			defer copy.Close()
 			started := time.Now()
 			c.Check(copy.Ping(), IsNil)
-			done <- time.Now().Sub(started)
+			done <- time.Since(started)
 		}()
 
 		time.Sleep(300 * time.Millisecond)
@@ -1634,7 +1633,7 @@ func (s *S) TestPoolLimitMany(c *C) {
 	// connection to the master, over the limit. Once the goroutine
 	// above releases its socket, it should move on.
 	session.Ping()
-	delay := time.Now().Sub(before)
+	delay := time.Since(before)
 	c.Assert(delay > 3e9, Equals, true)
 	c.Assert(delay < 6e9, Equals, true)
 }

--- a/server.go
+++ b/server.go
@@ -46,15 +46,15 @@ type mongoServer struct {
 	tcpaddr       *net.TCPAddr
 	unusedSockets []*mongoSocket
 	liveSockets   []*mongoSocket
-	closed        bool
-	abended       bool
 	sync          chan bool
 	dial          dialer
 	pingValue     time.Duration
 	pingIndex     int
-	pingCount     uint32
 	pingWindow    [6]time.Duration
 	info          *mongoServerInfo
+	pingCount     uint32
+	closed        bool
+	abended       bool
 }
 
 type dialer struct {
@@ -305,7 +305,7 @@ func (server *mongoServer) pinger(loop bool) {
 		if err == nil {
 			start := time.Now()
 			_, _ = socket.SimpleQuery(&op)
-			delay := time.Now().Sub(start)
+			delay := time.Since(start)
 
 			server.pingWindow[server.pingIndex] = delay
 			server.pingIndex = (server.pingIndex + 1) % len(server.pingWindow)

--- a/session.go
+++ b/session.go
@@ -481,7 +481,7 @@ type urlInfo struct {
 }
 
 func extractURL(s string) (*urlInfo, error) {
-	strings.TrimPrefix(s, "mongodb://")
+	s = strings.TrimPrefix(s, "mongodb://")
 	info := &urlInfo{options: make(map[string]string)}
 	if c := strings.Index(s, "?"); c != -1 {
 		for _, pair := range strings.FieldsFunc(s[c+1:], isOptSep) {

--- a/session.go
+++ b/session.go
@@ -75,22 +75,22 @@ const (
 // multiple goroutines will cause them to share the same underlying socket.
 // See the documentation on Session.SetMode for more details.
 type Session struct {
-	m                sync.RWMutex
+	defaultdb        string
+	sourcedb         string
+	syncTimeout      time.Duration
+	sockTimeout      time.Duration
+	poolLimit        int
+	consistency      Mode
+	creds            []Credential
+	dialCred         *Credential
+	safeOp           *queryOp
 	cluster_         *mongoCluster
 	slaveSocket      *mongoSocket
 	masterSocket     *mongoSocket
-	slaveOk          bool
-	consistency      Mode
+	m                sync.RWMutex
 	queryConfig      query
-	safeOp           *queryOp
-	syncTimeout      time.Duration
-	sockTimeout      time.Duration
-	defaultdb        string
-	sourcedb         string
-	dialCred         *Credential
-	creds            []Credential
-	poolLimit        int
 	bypassValidation bool
+	slaveOk          bool
 }
 
 type Database struct {
@@ -133,10 +133,10 @@ type Iter struct {
 	err            error
 	op             getMoreOp
 	prefetch       float64
-	limit          int32
 	docsToReceive  int
 	docsBeforeMore int
 	timeout        time.Duration
+	limit          int32
 	timedout       bool
 	findCmd        bool
 }
@@ -328,23 +328,11 @@ type DialInfo struct {
 	// Addrs holds the addresses for the seed servers.
 	Addrs []string
 
-	// Direct informs whether to establish connections only with the
-	// specified seed servers, or to obtain information for the whole
-	// cluster and establish connections with further servers too.
-	Direct bool
-
 	// Timeout is the amount of time to wait for a server to respond when
 	// first connecting and on follow up operations in the session. If
 	// timeout is zero, the call may block forever waiting for a connection
 	// to be established. Timeout does not affect logic in DialServer.
 	Timeout time.Duration
-
-	// FailFast will cause connection and query attempts to fail faster when
-	// the server is unavailable, instead of retrying until the configured
-	// timeout period. Note that an unavailable server may silently drop
-	// packets instead of rejecting them, in which case it's impossible to
-	// distinguish it from a slow server, so the timeout stays relevant.
-	FailFast bool
 
 	// Database is the default database name used when the Session.DB method
 	// is called with an empty name, and is also used during the initial
@@ -383,6 +371,18 @@ type DialInfo struct {
 	// PoolLimit defines the per-server socket pool limit. Defaults to 4096.
 	// See Session.SetPoolLimit for details.
 	PoolLimit int
+
+	// FailFast will cause connection and query attempts to fail faster when
+	// the server is unavailable, instead of retrying until the configured
+	// timeout period. Note that an unavailable server may silently drop
+	// packets instead of rejecting them, in which case it's impossible to
+	// distinguish it from a slow server, so the timeout stays relevant.
+	FailFast bool
+
+	// Direct informs whether to establish connections only with the
+	// specified seed servers, or to obtain information for the whole
+	// cluster and establish connections with further servers too.
+	Direct bool
 
 	// DialServer optionally specifies the dial function for establishing
 	// connections with the MongoDB servers.
@@ -481,9 +481,7 @@ type urlInfo struct {
 }
 
 func extractURL(s string) (*urlInfo, error) {
-	if strings.HasPrefix(s, "mongodb://") {
-		s = s[10:]
-	}
+	strings.TrimPrefix(s, "mongodb://")
 	info := &urlInfo{options: make(map[string]string)}
 	if c := strings.Index(s, "?"); c != -1 {
 		for _, pair := range strings.FieldsFunc(s[c+1:], isOptSep) {
@@ -1061,9 +1059,6 @@ type Collation struct {
 	// Locale defines the collation locale.
 	Locale string `bson:"locale"`
 
-	// CaseLevel defines whether to turn case sensitivity on at strength 1 or 2.
-	CaseLevel bool `bson:"caseLevel,omitempty"`
-
 	// CaseFirst may be set to "upper" or "lower" to define whether
 	// to have uppercase or lowercase items first. Default is "off".
 	CaseFirst string `bson:"caseFirst,omitempty"`
@@ -1086,15 +1081,18 @@ type Collation struct {
 	// Strength defaults to 3.
 	Strength int `bson:"strength,omitempty"`
 
-	// NumericOrdering defines whether to order numbers based on numerical
-	// order and not collation order.
-	NumericOrdering bool `bson:"numericOrdering,omitempty"`
-
 	// Alternate controls whether spaces and punctuation are considered base characters.
 	// May be set to "non-ignorable" (spaces and punctuation considered base characters)
 	// or "shifted" (spaces and punctuation not considered base characters, and only
 	// distinguished at strength > 3). Defaults to "non-ignorable".
 	Alternate string `bson:"alternate,omitempty"`
+
+	// CaseLevel defines whether to turn case sensitivity on at strength 1 or 2.
+	CaseLevel bool `bson:"caseLevel,omitempty"`
+
+	// NumericOrdering defines whether to order numbers based on numerical
+	// order and not collation order.
+	NumericOrdering bool `bson:"numericOrdering,omitempty"`
 
 	// Backwards defines whether to have secondary differences considered in reverse order,
 	// as done in the French language.
@@ -4020,11 +4018,11 @@ type mapReduceCmd struct {
 	Map        string ",omitempty"
 	Reduce     string ",omitempty"
 	Finalize   string ",omitempty"
-	Limit      int32  ",omitempty"
 	Out        interface{}
 	Query      interface{} ",omitempty"
 	Sort       interface{} ",omitempty"
 	Scope      interface{} ",omitempty"
+	Limit      int32       ",omitempty"
 	Verbose    bool        ",omitempty"
 }
 

--- a/socket.go
+++ b/socket.go
@@ -67,18 +67,17 @@ const (
 )
 
 type queryOp struct {
-	collection string
 	query      interface{}
+	collection string
+	serverTags []bson.D
+	selector   interface{}
+	replyFunc  replyFunc
+	mode       Mode
 	skip       int32
 	limit      int32
-	selector   interface{}
-	flags      queryOpFlags
-	replyFunc  replyFunc
-
-	mode       Mode
 	options    queryWrapper
 	hasOptions bool
-	serverTags []bson.D
+	flags      queryOpFlags
 }
 
 type queryWrapper struct {


### PR DESCRIPTION
1. [aligncheck](https://github.com/opennota/check) for better memory use
2. [gosimple](https://github.com/dominikh/go-simple) for time.Since instead time.Now().Sub