### PR TITLE
Avoid fixing the value of timeout for the dialing

### DIFF
--- a/session.go
+++ b/session.go
@@ -422,7 +422,7 @@ func DialWithInfo(info *DialInfo) (*Session, error) {
 		}
 		addrs[i] = addr
 	}
-	cluster := newCluster(addrs, info.Direct, info.FailFast, dialer{info.Dial, info.DialServer}, info.ReplicaSetName)
+	cluster := newCluster(addrs, info.Direct, info.FailFast, dialer{info.Dial, info.DialServer}, info.Timeout, info.ReplicaSetName)
 	session := newSession(Eventual, cluster, info.Timeout)
 	session.defaultdb = info.Database
 	if session.defaultdb == "" {


### PR DESCRIPTION
The value of timeout used while dialing is fixed with 10 seconds.
In some cases, the required dialing time is greater than this value, resulting in a failed dialing.

So I think we should set this value equal to the value of `timeout` parameter in `session.DialWithTimeout` function.

@niemeyer 


