### PR TITLE
Avoid interrupt inflight requests after a new socket connect failed

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -122,10 +122,10 @@ func (cluster *mongoCluster) removeServer(server *mongoServer) {
 	other := cluster.servers.Remove(server)
 	cluster.Unlock()
 	if other != nil {
-		other.Close()
+		other.CloseIdle()
 		log("Removed server ", server.Addr, " from cluster.")
 	}
-	server.Close()
+	server.CloseIdle()
 }
 
 type isMasterResult struct {

--- a/socket.go
+++ b/socket.go
@@ -320,6 +320,8 @@ func (socket *mongoSocket) Close() {
 	socket.kill(errors.New("Closed explicitly"), false)
 }
 
+// CloseAfterIdle terminates an idle socket, which has a zero
+// reference, or marks the socket to be terminate after idle.
 func (socket *mongoSocket) CloseAfterIdle() {
 	socket.Lock()
 	if socket.references == 0 {


### PR DESCRIPTION
If mongoServer fail to dial server, it will close all sockets that are alive, whether they're currently use or not.
There are two cons:
- Inflight requests  will be interrupt rudely.
- All sockets closed at the same time, and likely to dial server at the same time. Any occasional fail in the massive dial requests (high concurrency scenario) will make all sockets closed again, and repeat...(It happened in our production environment)

So I think sockets currently in use should closed after idle.