### PR TITLE
Hide deprecated warnings when building internal/sasl package

### DIFF
--- a/internal/sasl/sasl.go
+++ b/internal/sasl/sasl.go
@@ -8,6 +8,7 @@
 package sasl
 
 // #cgo LDFLAGS: -lsasl2
+// #cgo CFLAGS: -Wno-deprecated-declarations
 //
 // struct sasl_conn {};
 //


### PR DESCRIPTION
This is intended to address https://github.com/go-mgo/mgo/issues/234