### PR TITLE
Cache Transaction Ids

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1477,7 +1477,6 @@ func (s *S) TestSecondaryModeWithMongosInsert(c *C) {
 	c.Assert(result.A, Equals, 1)
 }
 
-
 func (s *S) TestRemovalOfClusterMember(c *C) {
 	if *fast {
 		c.Skip("-fast")

--- a/txn/flusher.go
+++ b/txn/flusher.go
@@ -12,7 +12,7 @@ func flush(r *Runner, t *transaction) error {
 		Runner:   r,
 		goal:     t,
 		goalKeys: make(map[docKey]bool),
-		queue:    make(map[docKey][]token),
+		queue:    make(map[docKey][]tokenAndId),
 		debugId:  debugPrefix(),
 	}
 	for _, dkey := range f.goal.docKeys() {
@@ -25,8 +25,34 @@ type flusher struct {
 	*Runner
 	goal     *transaction
 	goalKeys map[docKey]bool
-	queue    map[docKey][]token
+	queue    map[docKey][]tokenAndId
 	debugId  string
+}
+
+type tokenAndId struct {
+	tt  token
+	bid bson.ObjectId
+}
+
+func (ti tokenAndId) id() bson.ObjectId {
+	return ti.bid
+}
+
+func (ti tokenAndId) nonce() string {
+	return ti.tt.nonce()
+}
+
+func (ti tokenAndId) String() string {
+	return string(ti.tt)
+}
+
+func tokensWithIds(q []token) []tokenAndId {
+	out := make([]tokenAndId, len(q))
+	for i, tt := range q {
+		out[i].tt = tt
+		out[i].bid = tt.id()
+	}
+	return out
 }
 
 func (f *flusher) run() (err error) {
@@ -247,7 +273,7 @@ NextDoc:
 			if info.Remove == "" {
 				// Fast path, unless workload is insert/remove heavy.
 				revno[dkey] = info.Revno
-				f.queue[dkey] = info.Queue
+				f.queue[dkey] = tokensWithIds(info.Queue)
 				f.debugf("[A] Prepared document %v with revno %d and queue: %v", dkey, info.Revno, info.Queue)
 				continue NextDoc
 			} else {
@@ -309,7 +335,7 @@ NextDoc:
 					f.debugf("[B] Prepared document %v with revno %d and queue: %v", dkey, info.Revno, info.Queue)
 				}
 				revno[dkey] = info.Revno
-				f.queue[dkey] = info.Queue
+				f.queue[dkey] = tokensWithIds(info.Queue)
 				continue NextDoc
 			}
 		}
@@ -451,7 +477,7 @@ func (f *flusher) rescan(t *transaction, force bool) (revnos []int64, err error)
 				break
 			}
 		}
-		f.queue[dkey] = info.Queue
+		f.queue[dkey] = tokensWithIds(info.Queue)
 		if !found {
 			// Rescanned transaction id was not in the queue. This could mean one
 			// of three things:
@@ -515,12 +541,13 @@ func assembledRevnos(ops []Op, revno map[docKey]int64) []int64 {
 
 func (f *flusher) hasPreReqs(tt token, dkeys docKeys) (prereqs, found bool) {
 	found = true
+	ttId := tt.id()
 NextDoc:
 	for _, dkey := range dkeys {
 		for _, dtt := range f.queue[dkey] {
-			if dtt == tt {
+			if dtt.tt == tt {
 				continue NextDoc
-			} else if dtt.id() != tt.id() {
+			} else if dtt.id() != ttId {
 				prereqs = true
 			}
 		}
@@ -908,17 +935,17 @@ func (f *flusher) apply(t *transaction, pull map[bson.ObjectId]*transaction) err
 	return nil
 }
 
-func tokensToPull(dqueue []token, pull map[bson.ObjectId]*transaction, dontPull token) []token {
+func tokensToPull(dqueue []tokenAndId, pull map[bson.ObjectId]*transaction, dontPull token) []token {
 	var result []token
 	for j := len(dqueue) - 1; j >= 0; j-- {
 		dtt := dqueue[j]
-		if dtt == dontPull {
+		if dtt.tt == dontPull {
 			continue
 		}
 		if _, ok := pull[dtt.id()]; ok {
 			// It was handled before and this is a leftover invalid
 			// nonce in the queue. Cherry-pick it out.
-			result = append(result, dtt)
+			result = append(result, dtt.tt)
 		}
 	}
 	return result

--- a/txn/sim_test.go
+++ b/txn/sim_test.go
@@ -2,11 +2,11 @@ package txn_test
 
 import (
 	"flag"
+	. "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/dbtest"
 	"gopkg.in/mgo.v2/txn"
-	. "gopkg.in/check.v1"
 	"math/rand"
 	"time"
 )

--- a/txn/tarjan_test.go
+++ b/txn/tarjan_test.go
@@ -2,8 +2,8 @@ package txn
 
 import (
 	"fmt"
-	"gopkg.in/mgo.v2/bson"
 	. "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
 )
 
 type TarjanSuite struct{}


### PR DESCRIPTION
This could be landed in v2-unstable, but it was built off of v2, which apparently has many commits that aren't in v2-unstable.

When dealing with records that have many transactions in their txn-queue, one of the top consumers of CPU is actually the conversion from Token to ObjectId. The primary culprit of this was hasPreReq, which walks all of the tokens in a document and compares the object ID to some other object ID, and essentially converts every Token to an ID multiple times.

This is part of a series of small fixes I've put together around making handling large TXN queues a little bit nicer. It includes some test cases that expose where the problems are, and the patches to make those test cases a bit nicer.

The first commit is just running 'go fmt' which apparently reorders a few imports.

The second introduces the tests, so that you can get an impression of baseline performance. You can see the performance by running:
 cd mgo.v2/txn
 go test -check.vv -check.f TxnQueue -qlength 100 # 200, 400, 800, 1600, etc

You can see the O(N^2) performance. I've put together a spreadsheet showing the changes with various patches. https://docs.google.com/spreadsheets/d/1OXcIMooO8fG3xzLmn_4WSECLDdXBjQ-cKzkk26hovNU/edit?usp=sharing

The key indicators on the graphs for this patch are the Blue Circles and the Red Triangles. 
This patch has the biggest impact on Setup Prepared, ResumeAll Prepared, Setup Preparing and ResumeAll preparing (less of an impact on AssertionGrowth).

The algorithm is still fundamentally O(N^2) because we are re-reading the document from the database N times and it has N transaction tokens on the document. And the time to convert from BSON into Go objects is a significant portion of the time. Converting from Token to ObjectId was the other significant portion of the time, which is what this patch addresses.

I chose to break up the work into smaller performance tweaks so we can discuss them reasonably independently.