### PR TITLE
Add Hint and MaxTimeMS support to Count()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,6 @@ script:
     - (cd bson && go test -check.v)
     - go test -check.v -fast
     - (cd txn && go test -check.v)
+    - make stopdb
 
 # vim:sw=4:ts=4:et

--- a/harness/daemons/.env
+++ b/harness/daemons/.env
@@ -43,7 +43,7 @@ COMMONSOPTS="
 
 if versionAtLeast 3 2; then
 	# 3.2 doesn't like --nojournal on config servers.
-	COMMONCOPTS="$(echo "$COMMONCOPTS" | sed '/--nojournal/d')"
+	#COMMONCOPTS="$(echo "$COMMONCOPTS" | sed '/--nojournal/d')"
 	# Using a hacked version of MongoDB 3.2 for now.
 
 	# Go back to MMAPv1 so it's not super sluggish. :-(

--- a/harness/daemons/.env
+++ b/harness/daemons/.env
@@ -43,7 +43,7 @@ COMMONSOPTS="
 
 if versionAtLeast 3 2; then
 	# 3.2 doesn't like --nojournal on config servers.
-	#COMMONCOPTS="$(echo "$COMMONCOPTS" | sed '/--nojournal/d')"
+	COMMONCOPTS="$(echo "$COMMONCOPTS" | sed '/--nojournal/d')"
 	# Using a hacked version of MongoDB 3.2 for now.
 
 	# Go back to MMAPv1 so it's not super sluggish. :-(

--- a/session.go
+++ b/session.go
@@ -3941,10 +3941,12 @@ func (iter *Iter) getMoreCmd() *queryOp {
 }
 
 type countCmd struct {
-	Count string
-	Query interface{}
-	Limit int32 ",omitempty"
-	Skip  int32 ",omitempty"
+	Count     string
+	Query     interface{}
+	Limit     int32  ",omitempty"
+	Skip      int32  ",omitempty"
+	Hint      bson.D `bson:"hint,omitempty"`
+	MaxTimeMS int    `bson:"maxTimeMS,omitempty"`
 }
 
 // Count returns the total number of documents in the result set.
@@ -3966,8 +3968,12 @@ func (q *Query) Count() (n int, err error) {
 	if query == nil {
 		query = bson.D{}
 	}
+	// not checking the error because if type assertion fails, we
+	// simply want a Zero bson.D
+	hint, _ := q.op.options.Hint.(bson.D)
 	result := struct{ N int }{}
-	err = session.DB(dbname).Run(countCmd{cname, query, limit, op.skip}, &result)
+	err = session.DB(dbname).Run(countCmd{cname, query, limit, op.skip, hint, op.options.MaxTimeMS}, &result)
+
 	return result.N, err
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -1188,6 +1188,10 @@ func (s *S) TestCountSkipLimit(c *C) {
 }
 
 func (s *S) TestCountMaxTimeMS(c *C) {
+	if !s.versionAtLeast(2, 6) {
+		c.Skip("SetMaxTime only supported in 2.6+")
+	}
+
 	session, err := mgo.Dial("localhost:40001")
 	c.Assert(err, IsNil)
 	defer session.Close()
@@ -1203,15 +1207,19 @@ func (s *S) TestCountMaxTimeMS(c *C) {
 	e := err.(*mgo.QueryError)
 	// We hope this query took longer than 1 ms, which triggers an error code 50
 	c.Assert(e.Code, Equals, 50)
+
 }
 
 func (s *S) TestCountHint(c *C) {
+	if !s.versionAtLeast(2, 6) {
+		c.Skip("Not implemented until mongo 2.5.5 https://jira.mongodb.org/browse/SERVER-2677")
+	}
+
 	session, err := mgo.Dial("localhost:40001")
 	c.Assert(err, IsNil)
 	defer session.Close()
 
 	coll := session.DB("mydb").C("mycoll")
-
 	err = coll.Insert(M{"n": 1})
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
Add Hint and MaxTimeMS to the countCmd struct.

Added two unit tests covering the changes.

I had to uncomment the `.env` file because locally I run mongo 3.2, if this messes anything else, I can undo it.

I have been using the Hint part of this patch for several months on production on collections with several millions of documents and works well :)

Fixes https://github.com/go-mgo/mgo/issues/364

