### PR TITLE
Stop all db instances after travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,6 @@ script:
     - (cd bson && go test -check.v)
     - go test -check.v -fast
     - (cd txn && go test -check.v)
+    - make stopdb
 
 # vim:sw=4:ts=4:et


### PR DESCRIPTION
If all tests pass, the builds for mongo earlier than 2.6 are still failing.
Running a clean up fixes the issue.