### PR TITLE
Set an upper limit of how large we will let txn-queues grow.

### DIFF
--- a/txn/flusher.go
+++ b/txn/flusher.go
@@ -212,8 +212,6 @@ var txnFields = bson.D{{"txn-queue", 1}, {"txn-revno", 1}, {"txn-remove", 1}, {"
 
 var errPreReqs = fmt.Errorf("transaction has pre-requisites and force is false")
 
-const maxTxnQueueLength = 1000
-
 // prepare injects t's id onto txn-queue for all affected documents
 // and collects the current txn-queue and txn-revno values during
 // the process. If the prepared txn-queue indicates that there are
@@ -246,7 +244,7 @@ NextDoc:
 		change.Upsert = false
 		chaos("")
 		if _, err := cquery.Apply(change, &info); err == nil {
-			if len(info.Queue) > maxTxnQueueLength {
+			if f.opts.MaxTxnQueueLength > 0 && len(info.Queue) > f.opts.MaxTxnQueueLength {
 				// abort with TXN Queue too long, but remove the entry we just added
 				innerErr := c.UpdateId(dkey.Id,
 					bson.D{{"$pullAll", bson.D{{"txn-queue", []token{tt}}}}})

--- a/txn/txn_test.go
+++ b/txn/txn_test.go
@@ -666,6 +666,78 @@ func (s *S) TestTxnQueueCustomMaxSize(c *C) {
 	s.checkTxnQueueLength(c, 100)
 }
 
+func (s *S) TestTxnQueueMultipleDocs(c *C) {
+	expectedLength := 100
+	maxDocs := 110
+	opts := txn.DefaultRunnerOptions()
+	opts.MaxTxnQueueLength = expectedLength
+	s.runner.SetOptions(opts)
+	txn.SetDebug(false)
+	createOps := []txn.Op{{
+		C:      "accounts",
+		Id:     0,
+		Insert: M{"balance": 1000},
+	}}
+	for i := 1; i < maxDocs; i++ {
+		createOps = append(createOps, txn.Op{
+			C:      "accounts",
+			Id:     i,
+			Insert: M{"balance": 0},
+		})
+	}
+	err := s.runner.Run(createOps, "", nil)
+	c.Assert(err, IsNil)
+	// Force a bad transaction into the queue
+	badTxnId := "deadbeef1234567812345678_12345678"
+	err = s.accounts.UpdateId(0, M{"$set": M{"txn-queue": []string{badTxnId}}})
+	c.Assert(err, IsNil)
+	for i := 1; i < expectedLength; i++ {
+		ops := []txn.Op{{
+			C:      "accounts",
+			Id:     0,
+			Update: M{"$inc": M{"balance": -1}},
+		}, {
+			C:      "accounts",
+			Id:     i,
+			Update: M{"$inc": M{"balance": 1}},
+		}}
+		err = s.runner.Run(ops, "", nil)
+		c.Assert(err, NotNil)
+		c.Assert(err, ErrorMatches, `cannot find transaction ObjectIdHex."deadbeef1234567812345678".`)
+	}
+	// Now that we've filled up the txn-queue of the first document, any
+	// further changes should be aborted
+	var doc bson.M
+	err = s.accounts.FindId(0).One(&doc)
+	c.Assert(err, IsNil)
+	c.Check(len(doc["txn-queue"].([]interface{})), Equals, expectedLength)
+	txn.SetDebug(true)
+	for i := 100; i < maxDocs; i++ {
+		ops := []txn.Op{{
+			C:      "accounts",
+			Id:     0,
+			Update: M{"$inc": M{"balance": -1}},
+		}, {
+			C:      "accounts",
+			Id:     i,
+			Update: M{"$inc": M{"balance": 1}},
+		}}
+		err = s.runner.Run(ops, "", nil)
+		c.Assert(err, NotNil)
+		c.Assert(err, Equals, txn.ErrAborted)
+	}
+	err = s.accounts.FindId(0).One(&doc)
+	c.Assert(err, IsNil)
+	c.Check(len(doc["txn-queue"].([]interface{})), Equals, expectedLength)
+	err = s.accounts.UpdateId(0, M{"$pullAll": M{"txn-queue": []string{badTxnId}}})
+	c.Assert(err, IsNil)
+	c.Log("Updated removing the invalid transaction")
+	// Now we should be able to cleanup
+	err = s.runner.ResumeAll()
+	c.Assert(err, IsNil)
+	c.Log("resumed all")
+}
+
 func (s *S) TestTxnQueueUnlimited(c *C) {
 	opts := txn.DefaultRunnerOptions()
 	// A value of 0 should mean 'unlimited'

--- a/txn/txn_test.go
+++ b/txn/txn_test.go
@@ -647,7 +647,7 @@ func (s *S) checkTxnQueueLength(c *C, expectedQueueLength int) {
 	c.Assert(err, IsNil)
 	c.Check(len(doc["txn-queue"].([]interface{})), Equals, expectedQueueLength)
 	err = s.runner.Run(ops, "", nil)
-	c.Assert(err, Equals, txn.ErrAborted)
+	c.Check(err, ErrorMatches, `txn-queue for 0 in "accounts" has too many transactions \(\d+\)`)
 	// The txn-queue should not have grown
 	err = s.accounts.FindId(0).One(&doc)
 	c.Assert(err, IsNil)
@@ -724,7 +724,7 @@ func (s *S) TestTxnQueueMultipleDocs(c *C) {
 		}}
 		err = s.runner.Run(ops, "", nil)
 		c.Assert(err, NotNil)
-		c.Assert(err, Equals, txn.ErrAborted)
+		c.Check(err, ErrorMatches, `txn-queue for 0 in "accounts" has too many transactions \(\d+\)`)
 	}
 	err = s.accounts.FindId(0).One(&doc)
 	c.Assert(err, IsNil)

--- a/txn/txn_test.go
+++ b/txn/txn_test.go
@@ -647,7 +647,7 @@ func (s *S) checkTxnQueueLength(c *C, expectedQueueLength int) {
 	c.Assert(err, IsNil)
 	c.Check(len(doc["txn-queue"].([]interface{})), Equals, expectedQueueLength)
 	err = s.runner.Run(ops, "", nil)
-	c.Check(err, ErrorMatches, `txn-queue for 0 in "accounts" has too many transactions \(\d+\)`)
+	c.Assert(err, Equals, txn.ErrAborted)
 	// The txn-queue should not have grown
 	err = s.accounts.FindId(0).One(&doc)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
When we have broken transaction data in the database (such as from
mongo getting OOM killed), it can cause cascade failure, where that
document ends up getting too many transactions queued up against it.

This can also happen if you have nothing but assert-only transactions against a
single document.

If we have lots of transactions, it becomes harder and harder to add
new entries and clearing out a large queue is O(N^2) which means capping it
is worthwhile. (It also makes the document grow until it hits max-doc-size.)

The upper bound is still quite large, so it should not be triggered if
everything is operating normally.