### PR TITLE
Fix GetBSON() method usage

### DIFF
--- a/bson/encode.go
+++ b/bson/encode.go
@@ -34,6 +34,7 @@ import (
 	"net/url"
 	"reflect"
 	"strconv"
+	"sync"
 	"time"
 )
 
@@ -58,13 +59,28 @@ var (
 
 const itoaCacheSize = 32
 
+const (
+	getterUnknown = iota
+	getterNone
+	getterTypeVal
+	getterTypePtr
+	getterAddr
+)
+
 var itoaCache []string
+
+var getterStyles map[reflect.Type]int
+var getterIface reflect.Type
+var getterMutex sync.RWMutex
 
 func init() {
 	itoaCache = make([]string, itoaCacheSize)
 	for i := 0; i != itoaCacheSize; i++ {
 		itoaCache[i] = strconv.Itoa(i)
 	}
+	var iface Getter
+	getterIface = reflect.TypeOf(&iface).Elem()
+	getterStyles = make(map[reflect.Type]int)
 }
 
 func itoa(i int) string {
@@ -72,6 +88,50 @@ func itoa(i int) string {
 		return itoaCache[i]
 	}
 	return strconv.Itoa(i)
+}
+
+func getterStyle(outt reflect.Type) int {
+	getterMutex.RLock()
+	style := getterStyles[outt]
+	getterMutex.RUnlock()
+	if style == getterUnknown {
+		getterMutex.Lock()
+		defer getterMutex.Unlock()
+		if outt.Implements(getterIface) {
+			vt := outt
+			for vt.Kind() == reflect.Ptr {
+				vt = vt.Elem()
+			}
+			if vt.Implements(getterIface) {
+				getterStyles[outt] = getterTypeVal
+			} else {
+				getterStyles[outt] = getterTypePtr
+			}
+		} else if reflect.PtrTo(outt).Implements(getterIface) {
+			getterStyles[outt] = getterAddr
+		} else {
+			getterStyles[outt] = getterNone
+		}
+		style = getterStyles[outt]
+	}
+	return style
+}
+
+func getGetter(outt reflect.Type, out reflect.Value) Getter {
+	style := getterStyle(outt)
+	if style == getterNone {
+		return nil
+	}
+	if style == getterAddr {
+		if !out.CanAddr() {
+			return nil
+		}
+		return out.Addr().Interface().(Getter)
+	}
+	if style == getterTypeVal && out.Kind() == reflect.Ptr && out.IsNil() {
+		return nil
+	}
+	return out.Interface().(Getter)
 }
 
 // --------------------------------------------------------------------------
@@ -251,7 +311,7 @@ func (e *encoder) addElem(name string, v reflect.Value, minSize bool) {
 		return
 	}
 
-	if getter, ok := v.Interface().(Getter); ok {
+	if getter := getGetter(v.Type(), v); getter != nil {
 		getv, err := getter.GetBSON()
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Original issue
---

You can't use type with custom GetBSON() method mixed with structure field type and structure field reference type.

For example, you can't create custom GetBSON() for Bar type:

```
struct Foo {
	a  Bar
	b *Bar
}
```

Type implementation (`func (t Bar) GetBSON()` ) would crash on `Foo.b = nil` value encoding.

Reference implementation (`func (t *Bar) GetBSON()` ) would not call on `Foo.a` value encoding.

After this change
---

For type implementation  `func (t Bar) GetBSON()` would not call on `Foo.b = nil` value encoding.
In this case `nil` value would be seariazied as `nil` BSON value.

For reference implementation `func (t *Bar) GetBSON()` would call even on `Foo.a` value encoding.