### PR TITLE
Document QueryError

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,14 @@
+package mgo
+
+import "fmt"
+
+func ExampleQueryError() {
+	e := &QueryError{
+		Code:      17406,
+		Message:   "getMore executor error: CappedPositionLost: CollectionScan died due to failure to restore tailable cursor position. Last seen record id: RecordId(200138)",
+		Assertion: false,
+	}
+	fmt.Println(e.String())
+	// Output:
+	// getMore executor error: CappedPositionLost: CollectionScan died due to failure to restore tailable cursor position. Last seen record id: RecordId(200138)
+}

--- a/session.go
+++ b/session.go
@@ -2397,7 +2397,10 @@ type queryError struct {
 	AssertionCode int "assertionCode"
 }
 
+// QueryError indicates an error that occurred during a Mongo query.
 type QueryError struct {
+	// A list of codes can be found here:
+	// https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.err
 	Code      int
 	Message   string
 	Assertion bool


### PR DESCRIPTION
Also give an example of an error returned as a QueryError in
production, so you can see what e.g. the Message field may look like.