### PR TITLE
Add support for allowing partial results from scatter-gather queries

### DIFF
--- a/session.go
+++ b/session.go
@@ -2973,6 +2973,13 @@ func (q *Query) SetMaxTime(d time.Duration) *Query {
 	return q
 }
 
+func (q *Query) AllowPartial() *Query {
+	q.m.Lock()
+	q.op.AllowPartial()
+	q.m.Unlock()
+	return q
+}
+
 // Snapshot will force the performed query to make use of an available
 // index on the _id field to prevent the same document from being returned
 // more than once in a single iteration. This might happen without this
@@ -3149,18 +3156,19 @@ func prepareFindOp(socket *mongoSocket, op *queryOp, limit int32) bool {
 	}
 
 	find := findCmd{
-		Collection:  op.collection[nameDot+1:],
-		Filter:      op.query,
-		Projection:  op.selector,
-		Sort:        op.options.OrderBy,
-		Skip:        op.skip,
-		Limit:       limit,
-		MaxTimeMS:   op.options.MaxTimeMS,
-		MaxScan:     op.options.MaxScan,
-		Hint:        op.options.Hint,
-		Comment:     op.options.Comment,
-		Snapshot:    op.options.Snapshot,
-		OplogReplay: op.flags&flagLogReplay != 0,
+		Collection:          op.collection[nameDot+1:],
+		Filter:              op.query,
+		Projection:          op.selector,
+		Sort:                op.options.OrderBy,
+		Skip:                op.skip,
+		Limit:               limit,
+		MaxTimeMS:           op.options.MaxTimeMS,
+		MaxScan:             op.options.MaxScan,
+		Hint:                op.options.Hint,
+		Comment:             op.options.Comment,
+		Snapshot:            op.options.Snapshot,
+		OplogReplay:         op.flags&flagLogReplay != 0,
+		AllowPartialResults: op.flags&flagPartial != 0,
 	}
 	if op.limit < 0 {
 		find.BatchSize = -op.limit

--- a/socket.go
+++ b/socket.go
@@ -64,6 +64,8 @@ const (
 	flagLogReplay
 	flagNoCursorTimeout
 	flagAwaitData
+	flagExhaust
+	flagPartial
 )
 
 type queryOp struct {
@@ -91,6 +93,10 @@ type queryWrapper struct {
 	MaxScan        int         "$maxScan,omitempty"
 	MaxTimeMS      int         "$maxTimeMS,omitempty"
 	Comment        string      "$comment,omitempty"
+}
+
+func (op *queryOp) AllowPartial() {
+	op.flags |= flagPartial
 }
 
 func (op *queryOp) finalQuery(socket *mongoSocket) interface{} {


### PR DESCRIPTION
As title indicates, this is useful to allow a scatter-gather query to return partial results when a non-zero number of replica sets are down.