### PR TITLE
Allowed Comment for findAndModify

### DIFF
--- a/session.go
+++ b/session.go
@@ -4134,12 +4134,14 @@ type Change struct {
 	Upsert    bool        // Whether to insert in case the document isn't found
 	Remove    bool        // Whether to remove the document found rather than updating
 	ReturnNew bool        // Should the modified document be returned rather than the old one
+	Comment   string      // The comment to be applied on the findAndModify
 }
 
 type findModifyCmd struct {
 	Collection                  string      "findAndModify"
 	Query, Update, Sort, Fields interface{} ",omitempty"
 	Upsert, Remove, New         bool        ",omitempty"
+	Comment                     string
 }
 
 type valueResult struct {


### PR DESCRIPTION
findAndModify has a differing syntax for adding comments. We pass the comment through on the Get side, but it just gets lost since the syntax isn't right. One way to fix this is to explicitly pass the Comment through here. I checked the go-mgo/mgo stuff they haven't done this.

This to me is cleaner than trying to parse it out of the bson fields. 