### PR TITLE
Allow adding a comment for FindAndModify queries

### DIFF
--- a/session.go
+++ b/session.go
@@ -4134,12 +4134,14 @@ type Change struct {
 	Upsert    bool        // Whether to insert in case the document isn't found
 	Remove    bool        // Whether to remove the document found rather than updating
 	ReturnNew bool        // Should the modified document be returned rather than the old one
+	Comment   string      // Comment for findAndModify
 }
 
 type findModifyCmd struct {
 	Collection                  string      "findAndModify"
 	Query, Update, Sort, Fields interface{} ",omitempty"
 	Upsert, Remove, New         bool        ",omitempty"
+	Comment                     string      ",omitempty"
 }
 
 type valueResult struct {


### PR DESCRIPTION
findAndModify has a slightly different syntax for comments:  

db.users.findAndModify( {
   query: { "_id": NumberLong("1") },
   update: { $set: { currentRideId: 2 } },
   comment: "oh"
} );

The comment that we pass in on the getSide just gets lost. We need to explicitly add it when we're creating the findAndModify query.