### PR TITLE
Fix the Raw Unmarshaller not to populate empty structs when there is no data

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -558,6 +558,12 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 // See the Unmarshal function documentation for more details on the
 // unmarshalling process.
 func (raw Raw) Unmarshal(out interface{}) (err error) {
+	// If there is no data to unmarshal dont set out to an empty struct.
+	// This breaks read your own write semantics.
+	// For example, we end up a reading an empty struct from the db where there is no value for that in the db.
+	if len(raw.Data) == 0 {
+		return SetZero
+	}
 	defer handleErr(&err)
 	v := reflect.ValueOf(out)
 	switch v.Kind() {


### PR DESCRIPTION
The `Raw` unmarshaller doesnt return the correct error code, indicating there is no data to unmarshal. This leads to empty struct creations on the read path.
So for example consider the following:
```go
        type rawMongoOSModel struct {
	    Name        string    `dynamodbav:"name,omitempty"`
	    ReleaseDate time.Time `dynamodbav:"release_date,omitempty"`
       }
	var n rawMongoOSModel
	if err := raw.Unmarshal(&n); err != nil {
		return err
	}
```
if there is no data to be unmarshalled we still get the out parameter populated to an empty `rawMongoOSModel` which leads to behaviors where one cant read their own writes and get the object as equal.


Currently I couldnt add tests, since the test framework is testing an unstable branch for the marshal code!! 