### PR TITLE
Fix the socket read/write fatal deadlock problem when a large number of concurrent requests or a large amount of data is written at the same time

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -532,22 +532,22 @@ func (socket *mongoSocket) Query(ops ...interface{}) (err error) {
 		n, err := socket.conn.Write(buf[writeCount:])
 		if err != nil {
 			socket.writeLock.Unlock()
-			socket.Lock()
 			if !wasWaiting && requestCount > 0 {
+				socket.Lock()
 				socket.updateDeadline(readDeadline)
+				socket.Unlock()
 			}
-			socket.Unlock()
 			return err
 		}
 		writeCount += n
 	}
 	socket.writeLock.Unlock()
 
-	socket.Lock()
 	if !wasWaiting && requestCount > 0 {
+		socket.Lock()
 		socket.updateDeadline(readDeadline)
+		socket.Unlock()
 	}
-	socket.Unlock()
 	return err
 }
 


### PR DESCRIPTION
When a large number of concurrent requests or a large amount of data is written at the same time, the connection send buffer may be exceeded or the database processing speed may be exceeded, and the data not completely written will be discarded, which will lead to deadlock due to incomplete connection transfer protocol data.

The connection state management and connection write data are completely separate, and the connection state is not changed when writing data, so the write data should be released with an independent lock and the state management lock, otherwise it may lead to read results that cannot get the state lock to read the results, and then further lead to deadlock when the connection write data cannot be completed.


Testing Code
```
// main
package main

import (
	"fmt"
	"gopkg.in/mgo.v2"
	"gopkg.in/mgo.v2/bson"
	"sync"
	"time"
)

var count = 0
var wait = make(chan int64)
var lock = sync.Mutex{}

type MgoLog struct {
}

func (self MgoLog) Output(i int, msg string) error {
	fmt.Println(i, " ", msg)
	return nil
}

func test(session *mgo.Session, index int) {
	start_time := time.Now().Unix()
	weixin := make(map[string]interface{})
	c := session.DB("test").C("test").Find(bson.M{})
	c.One(weixin)

	lock.Lock()
	defer lock.Unlock()
	count += 1
	t := time.Now().Unix() - start_time
	fmt.Println(t, " ", index, " ", count)
	if count >= 100000 {
		wait <- t
	}
}

func main() {
	mgo.SetLogger(MgoLog{})
	session, err := mgo.Dial("172.16.0.2:27017")

	if err != nil {
		fmt.Println(err)
		return
	}
	fmt.Println(session.BuildInfo())
	fmt.Println(session.LiveServers())

	for i := 0; i < 100001; i++ {
		go test(session, i)
	}

	<-wait
	fmt.Println(session.LiveServers())
}
```